### PR TITLE
Sysvinit 2.89

### DIFF
--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -8376,6 +8376,7 @@ static int talk_initctl(void) {
         _cleanup_close_ int fd = -1;
         char rl;
         int r;
+        const char *p;
 
         rl = action_to_runlevel();
         if (!rl)
@@ -8383,17 +8384,21 @@ static int talk_initctl(void) {
 
         request.runlevel = rl;
 
-        fd = open(INIT_FIFO, O_WRONLY|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
+        FOREACH_STRING(p, "/run/initctl", "/dev/initctl") {
+                fd = open(p, O_WRONLY|O_NONBLOCK|O_CLOEXEC|O_NOCTTY);
+                if (fd >= 0 || errno != ENOENT)
+                        break;
+        }
         if (fd < 0) {
                 if (errno == ENOENT)
                         return 0;
 
-                return log_error_errno(errno, "Failed to open "INIT_FIFO": %m");
+                return log_error_errno(errno, "Failed to open initctl fifo: %m");
         }
 
         r = loop_write(fd, &request, sizeof(request), false);
         if (r < 0)
-                return log_error_errno(r, "Failed to write to "INIT_FIFO": %m");
+                return log_error_errno(r, "Failed to write to %s: %m", p);
 
         return 1;
 #else

--- a/units/systemd-initctl.service.in
+++ b/units/systemd-initctl.service.in
@@ -8,7 +8,7 @@
 #  (at your option) any later version.
 
 [Unit]
-Description=/dev/initctl Compatibility Daemon
+Description=initctl Compatibility Daemon
 Documentation=man:systemd-initctl.service(8)
 DefaultDependencies=no
 

--- a/units/systemd-initctl.socket
+++ b/units/systemd-initctl.socket
@@ -8,12 +8,12 @@
 #  (at your option) any later version.
 
 [Unit]
-Description=/dev/initctl Compatibility Named Pipe
+Description=initctl Compatibility Named Pipe
 Documentation=man:systemd-initctl.service(8)
 DefaultDependencies=no
 Before=sockets.target
 
 [Socket]
-ListenFIFO=/run/systemd/initctl/fifo
+ListenFIFO=/run/initctl
 Symlinks=/dev/initctl
 SocketMode=0600


### PR DESCRIPTION
Cherry-pick compat with Sysvinit 2.89

These two patches are applied in Debian and Ubuntu.