### PR TITLE
login: change variable type of enable_wall_messages as it matches Man…

### DIFF
--- a/src/login/logind-dbus.c
+++ b/src/login/logind-dbus.c
@@ -2491,7 +2491,7 @@ static int method_set_wall_message(
         int r;
         Manager *m = userdata;
         char *wall_message;
-        int enable_wall_messages;
+        unsigned enable_wall_messages;
 
         assert(message);
         assert(m);


### PR DESCRIPTION
…ager.enable_wall_messages

(cherry picked from commit c9482b88228db25c77ad61e119f61308af8fe2e9)

Applied in Debian & Ubuntu. Related to the cherrypicked a9e23be7f0f183615f640aa0e05c7844ea1e6233