### PR TITLE
journald: fix silent loss of messages

### DIFF
--- a/src/journal/journald-rate-limit.h
+++ b/src/journal/journald-rate-limit.h
@@ -26,3 +26,4 @@ typedef struct JournalRateLimit JournalRateLimit;
 JournalRateLimit *journal_rate_limit_new(usec_t interval, unsigned burst);
 void journal_rate_limit_free(JournalRateLimit *r);
 int journal_rate_limit_test(JournalRateLimit *r, const char *id, int priority, uint64_t available);
+int journal_rate_limit_test_all(JournalRateLimit *r, char **path, int priority);


### PR DESCRIPTION
Currently, `systemd-journald` may lose messages silently in some cases of
the reached rate limit. The expected behavior is to always log
"Suppressed ... messages".

This commit fixes the misbehavior.

Steps to reproduce:

0. Configuration:

~~~~
RateLimitInterval=4s
RateLimitBurst=16
~~~~

1. Before this commit - messages may become lost silently:

~~~~
$ echo 'line 0' > lines.txt
$ for i in $(seq 1 1023); do echo "line $i" >> lines.txt; done
$ for i in $(seq 0 1023); do logger -f lines.txt; done
$ journalctl | less
<...>
May 23 05:00:53 target root[3312]: line 1022
May 23 05:00:53 target root[3312]: line 1023
May 23 05:00:53 target root[3313]: line 766
May 23 05:00:53 target root[3313]: line 767
<...>
~~~~

2. After this commit - log "Suppressed ... messages":

~~~~
$ echo 'line 0' > lines.txt
$ for i in $(seq 1 1023); do echo "line $i" >> lines.txt; done
$ for i in $(seq 0 1023); do logger -f lines.txt; done
$ journalctl | less
<...>
May 23 04:59:54 target root[3306]: line 13
May 23 04:59:54 target root[3306]: line 14
May 23 04:59:54 target systemd-journald[1422]: Suppressed 755 messages from /system.slice/system-ssh
d.slice
May 23 04:59:54 target root[3306]: line 770
May 23 04:59:54 target root[3306]: line 771
<...>
~~~~