### PR TITLE
nspawn: chown() the legacy hierarchy when it's used in a container

### DIFF
--- a/src/nspawn/nspawn-cgroup.c
+++ b/src/nspawn/nspawn-cgroup.c
@@ -55,7 +55,7 @@ int chown_cgroup(pid_t pid, CGroupUnified unified_requested, uid_t uid_shift) {
         if (r < 0)
                 return log_error_errno(r, "Failed to chown() cgroup %s: %m", fs);
 
-        if (unified_requested == CGROUP_UNIFIED_SYSTEMD) {
+        if (unified_requested == CGROUP_UNIFIED_SYSTEMD || (unified_requested == CGROUP_UNIFIED_NONE && cg_unified_controller(SYSTEMD_CGROUP_CONTROLLER) > 0)) {
                 _cleanup_free_ char *lfs = NULL;
                 /* Always propagate access rights from unified to legacy controller */
 


### PR DESCRIPTION
This is a follow-up to 720f0a2f3c928cc9379501a52146be9fbb4d9be2.

See https://github.com/systemd/systemd/pull/10104

Closed https://github.com/systemd/systemd/issues/10026
Closed https://github.com/systemd/systemd/issues/9563

(cherry picked from commit 89f180201cd8c0f3ce5cb6e8dd7e2b3cbcf71527)

cc @evverx @Mic92 @poettering 