### PR TITLE
tree-wide: use structured initialization for sockaddr_un

### DIFF
--- a/src/libsystemd/sd-bus/sd-bus.c
+++ b/src/libsystemd/sd-bus/sd-bus.c
@@ -967,9 +967,11 @@ static int parse_container_unix_address(sd_bus *b, const char **p, char **guid) 
         } else
                 b->nspid = 0;
 
-        b->sockaddr.un.sun_family = AF_UNIX;
-        /* Note that we use the old /var/run prefix here, to increase compatibility with really old containers */
-        strncpy(b->sockaddr.un.sun_path, "/var/run/dbus/system_bus_socket", sizeof(b->sockaddr.un.sun_path));
+        b->sockaddr.un = (struct sockaddr_un) {
+                .sun_family = AF_UNIX,
+                /* Note that we use the old /var/run prefix here, to increase compatibility with really old containers */
+                .sun_path = "/var/run/dbus/system_bus_socket",
+        };
         b->sockaddr_size = SOCKADDR_UN_LEN(b->sockaddr.un);
         b->is_local = false;
 

--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -2770,7 +2770,8 @@ static int setup_sd_notify_child(void) {
         static const int one = 1;
         int fd = -1;
         union sockaddr_union sa = {
-                .sa.sa_family = AF_UNIX,
+                .un.sun_family = AF_UNIX,
+                .un.sun_path = NSPAWN_NOTIFY_SOCKET_PATH,
         };
         int r;
 
@@ -2781,11 +2782,10 @@ static int setup_sd_notify_child(void) {
         (void) mkdir_parents(NSPAWN_NOTIFY_SOCKET_PATH, 0755);
         (void) sockaddr_un_unlink(&sa.un);
 
-        strncpy(sa.un.sun_path, NSPAWN_NOTIFY_SOCKET_PATH, sizeof(sa.un.sun_path));
         r = bind(fd, &sa.sa, SOCKADDR_UN_LEN(sa.un));
         if (r < 0) {
                 safe_close(fd);
-                return log_error_errno(errno, "bind(%s) failed: %m", sa.un.sun_path);
+                return log_error_errno(errno, "bind(" NSPAWN_NOTIFY_SOCKET_PATH ") failed: %m");
         }
 
         r = userns_lchown(NSPAWN_NOTIFY_SOCKET_PATH, 0, 0);

--- a/src/udev/udev-ctrl.c
+++ b/src/udev/udev-ctrl.c
@@ -103,8 +103,11 @@ struct udev_ctrl *udev_ctrl_new_from_fd(struct udev *udev, int fd) {
         if (r < 0)
                 log_warning_errno(errno, "could not set SO_PASSCRED: %m");
 
-        uctrl->saddr.un.sun_family = AF_LOCAL;
-        strscpy(uctrl->saddr.un.sun_path, sizeof(uctrl->saddr.un.sun_path), "/run/udev/control");
+        uctrl->saddr.un = (struct sockaddr_un) {
+                .sun_family = AF_UNIX,
+                .sun_path = "/run/udev/control",
+        };
+
         uctrl->addrlen = SOCKADDR_UN_LEN(uctrl->saddr.un);
         return uctrl;
 }


### PR DESCRIPTION
Commit fbda85b078 ("tree-wide: use sockaddr_un_unlink() at two more places
where appropriate") was backported to stable, but it breaks
systemd-nspawn due to missing initialization of notify socket path. Also
backport commit to properly initialize it.

(cherry picked from commit 44ed5214add7b2c1048a9b8e6ca8cb99505a78eb)