### PR TITLE
Cherry-picks for build fixes, to build v237 on a modern toolchain

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -342,6 +342,10 @@ foreach arg : ['unused-parameter',
                'unused-result',
                'format-signedness',
                'error=nonnull', # work-around for gcc 7.1 turning this on on its own
+
+               # Disable -Wmaybe-uninitialized, since it's noisy on gcc 8 with
+               # optimizations enabled, producing essentially false positives.
+               'maybe-uninitialized',
               ]
         if cc.has_argument('-W' + arg)
                 add_project_arguments('-Wno-' + arg, language : 'c')

--- a/meson.build
+++ b/meson.build
@@ -782,11 +782,11 @@ conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
 substs.set('SUSHELL', get_option('debug-shell'))
 substs.set('DEBUGTTY', get_option('debug-tty'))
 
-debug = get_option('debug')
+debug_extra = get_option('debug-extra')
 enable_debug_hashmap = false
 enable_debug_mmap_cache = false
-if debug != ''
-        foreach name : debug.split(',')
+if debug_extra != ''
+        foreach name : debug_extra.split(',')
                 if name == 'hashmap'
                         enable_debug_hashmap = true
                 elif name == 'mmap-cache'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -51,7 +51,7 @@ option('debug-shell', type : 'string', value : '/bin/sh',
        description : 'path to debug shell binary')
 option('debug-tty', type : 'string', value : '/dev/tty9',
        description : 'specify the tty device for debug shell')
-option('debug', type : 'string',
+option('debug-extra', type : 'string',
        description : 'enable extra debugging (hashmap,mmap-cache)')
 
 option('utmp', type : 'boolean',

--- a/src/basic/log.c
+++ b/src/basic/log.c
@@ -808,7 +808,7 @@ static void log_assert(
         log_dispatch_internal(level, 0, file, line, func, NULL, NULL, NULL, NULL, buffer);
 }
 
-noreturn void log_assert_failed_realm(
+_noreturn_ void log_assert_failed_realm(
                 LogRealm realm,
                 const char *text,
                 const char *file,
@@ -820,7 +820,7 @@ noreturn void log_assert_failed_realm(
         abort();
 }
 
-noreturn void log_assert_failed_unreachable_realm(
+_noreturn_ void log_assert_failed_unreachable_realm(
                 LogRealm realm,
                 const char *text,
                 const char *file,

--- a/src/basic/log.h
+++ b/src/basic/log.h
@@ -199,7 +199,7 @@ int log_dump_internal(
                 char *buffer);
 
 /* Logging for various assertions */
-noreturn void log_assert_failed_realm(
+_noreturn_ void log_assert_failed_realm(
                 LogRealm realm,
                 const char *text,
                 const char *file,
@@ -208,7 +208,7 @@ noreturn void log_assert_failed_realm(
 #define log_assert_failed(text, ...) \
         log_assert_failed_realm(LOG_REALM, (text), __VA_ARGS__)
 
-noreturn void log_assert_failed_unreachable_realm(
+_noreturn_ void log_assert_failed_unreachable_realm(
                 LogRealm realm,
                 const char *text,
                 const char *file,

--- a/src/basic/macro.h
+++ b/src/basic/macro.h
@@ -53,6 +53,15 @@
 #else
 #define _fallthrough_
 #endif
+/* Define C11 noreturn without <stdnoreturn.h> and even on older gcc
+ * compiler versions */
+#ifndef _noreturn_
+#if __STDC_VERSION__ >= 201112L
+#define _noreturn_ _Noreturn
+#else
+#define _noreturn_ __attribute__((noreturn))
+#endif
+#endif
 
 /* Temporarily disable some warnings */
 #define DISABLE_WARNING_DECLARATION_AFTER_STATEMENT                     \
@@ -411,16 +420,6 @@ static inline unsigned long ALIGN_POWER2(unsigned long u) {
 #define thread_local _Thread_local
 #else
 #define thread_local __thread
-#endif
-#endif
-
-/* Define C11 noreturn without <stdnoreturn.h> and even on older gcc
- * compiler versions */
-#ifndef noreturn
-#if __STDC_VERSION__ >= 201112L
-#define noreturn _Noreturn
-#else
-#define noreturn __attribute__((noreturn))
 #endif
 #endif
 

--- a/src/basic/macro.h
+++ b/src/basic/macro.h
@@ -26,30 +26,30 @@
 #include <sys/sysmacros.h>
 #include <sys/types.h>
 
-#define _printf_(a,b) __attribute__ ((format (printf, a, b)))
+#define _printf_(a, b) __attribute__ ((__format__(printf, a, b)))
 #ifdef __clang__
 #  define _alloc_(...)
 #else
-#  define _alloc_(...) __attribute__ ((alloc_size(__VA_ARGS__)))
+#  define _alloc_(...) __attribute__ ((__alloc_size__(__VA_ARGS__)))
 #endif
-#define _sentinel_ __attribute__ ((sentinel))
-#define _unused_ __attribute__ ((unused))
-#define _destructor_ __attribute__ ((destructor))
-#define _pure_ __attribute__ ((pure))
-#define _const_ __attribute__ ((const))
-#define _deprecated_ __attribute__ ((deprecated))
-#define _packed_ __attribute__ ((packed))
-#define _malloc_ __attribute__ ((malloc))
-#define _weak_ __attribute__ ((weak))
-#define _likely_(x) (__builtin_expect(!!(x),1))
-#define _unlikely_(x) (__builtin_expect(!!(x),0))
-#define _public_ __attribute__ ((visibility("default")))
-#define _hidden_ __attribute__ ((visibility("hidden")))
-#define _weakref_(x) __attribute__((weakref(#x)))
-#define _alignas_(x) __attribute__((aligned(__alignof(x))))
-#define _cleanup_(x) __attribute__((cleanup(x)))
+#define _sentinel_ __attribute__ ((__sentinel__))
+#define _unused_ __attribute__ ((__unused__))
+#define _destructor_ __attribute__ ((__destructor__))
+#define _pure_ __attribute__ ((__pure__))
+#define _const_ __attribute__ ((__const__))
+#define _deprecated_ __attribute__ ((__deprecated__))
+#define _packed_ __attribute__ ((__packed__))
+#define _malloc_ __attribute__ ((__malloc__))
+#define _weak_ __attribute__ ((__weak__))
+#define _likely_(x) (__builtin_expect(!!(x), 1))
+#define _unlikely_(x) (__builtin_expect(!!(x), 0))
+#define _public_ __attribute__ ((__visibility__("default")))
+#define _hidden_ __attribute__ ((__visibility__("hidden")))
+#define _weakref_(x) __attribute__((__weakref__(#x)))
+#define _alignas_(x) __attribute__((__aligned__(__alignof(x))))
+#define _cleanup_(x) __attribute__((__cleanup__(x)))
 #if __GNUC__ >= 7
-#define _fallthrough_ __attribute__((fallthrough))
+#define _fallthrough_ __attribute__((__fallthrough__))
 #else
 #define _fallthrough_
 #endif
@@ -59,7 +59,7 @@
 #if __STDC_VERSION__ >= 201112L
 #define _noreturn_ _Noreturn
 #else
-#define _noreturn_ __attribute__((noreturn))
+#define _noreturn_ __attribute__((__noreturn__))
 #endif
 #endif
 

--- a/src/basic/parse-util.c
+++ b/src/basic/parse-util.c
@@ -531,6 +531,30 @@ int safe_atoi16(const char *s, int16_t *ret) {
         return 0;
 }
 
+int safe_atoux16(const char *s, uint16_t *ret) {
+        char *x = NULL;
+        unsigned long l;
+
+        assert(s);
+        assert(ret);
+
+        s += strspn(s, WHITESPACE);
+
+        errno = 0;
+        l = strtoul(s, &x, 16);
+        if (errno > 0)
+                return -errno;
+        if (!x || x == s || *x != 0)
+                return -EINVAL;
+        if (s[0] == '-')
+                return -ERANGE;
+        if ((unsigned long) (uint16_t) l != l)
+                return -ERANGE;
+
+        *ret = (uint16_t) l;
+        return 0;
+}
+
 int safe_atod(const char *s, double *ret_d) {
         _cleanup_(freelocalep) locale_t loc = (locale_t) 0;
         char *x = NULL;

--- a/src/basic/parse-util.h
+++ b/src/basic/parse-util.h
@@ -54,6 +54,8 @@ int safe_atou8(const char *s, uint8_t *ret);
 int safe_atou16(const char *s, uint16_t *ret);
 int safe_atoi16(const char *s, int16_t *ret);
 
+int safe_atoux16(const char *s, uint16_t *ret);
+
 static inline int safe_atou32(const char *s, uint32_t *ret_u) {
         assert_cc(sizeof(uint32_t) == sizeof(unsigned));
         return safe_atou(s, (unsigned*) ret_u);

--- a/src/basic/process-util.c
+++ b/src/basic/process-util.c
@@ -947,7 +947,7 @@ bool is_main_thread(void) {
         return cached > 0;
 }
 
-noreturn void freeze(void) {
+_noreturn_ void freeze(void) {
 
         log_close();
 

--- a/src/basic/process-util.h
+++ b/src/basic/process-util.h
@@ -91,7 +91,7 @@ int pid_from_same_root_fs(pid_t pid);
 
 bool is_main_thread(void);
 
-noreturn void freeze(void);
+_noreturn_ void freeze(void);
 
 bool oom_score_adjust_is_valid(int oa);
 

--- a/src/basic/sparse-endian.h
+++ b/src/basic/sparse-endian.h
@@ -28,8 +28,8 @@
 #include <stdint.h>
 
 #ifdef __CHECKER__
-#define __sd_bitwise __attribute__((bitwise))
-#define __sd_force __attribute__((force))
+#define __sd_bitwise __attribute__((__bitwise__))
+#define __sd_force __attribute__((__force__))
 #else
 #define __sd_bitwise
 #define __sd_force

--- a/src/basic/unaligned.h
+++ b/src/basic/unaligned.h
@@ -26,37 +26,37 @@
 /* BE */
 
 static inline uint16_t unaligned_read_be16(const void *_u) {
-        const struct __attribute__((packed, may_alias)) { uint16_t x; } *u = _u;
+        const struct __attribute__((__packed__, __may_alias__)) { uint16_t x; } *u = _u;
 
         return be16toh(u->x);
 }
 
 static inline uint32_t unaligned_read_be32(const void *_u) {
-        const struct __attribute__((packed, may_alias)) { uint32_t x; } *u = _u;
+        const struct __attribute__((__packed__, __may_alias__)) { uint32_t x; } *u = _u;
 
         return be32toh(u->x);
 }
 
 static inline uint64_t unaligned_read_be64(const void *_u) {
-        const struct __attribute__((packed, may_alias)) { uint64_t x; } *u = _u;
+        const struct __attribute__((__packed__, __may_alias__)) { uint64_t x; } *u = _u;
 
         return be64toh(u->x);
 }
 
 static inline void unaligned_write_be16(void *_u, uint16_t a) {
-        struct __attribute__((packed, may_alias)) { uint16_t x; } *u = _u;
+        struct __attribute__((__packed__, __may_alias__)) { uint16_t x; } *u = _u;
 
         u->x = be16toh(a);
 }
 
 static inline void unaligned_write_be32(void *_u, uint32_t a) {
-        struct __attribute__((packed, may_alias)) { uint32_t x; } *u = _u;
+        struct __attribute__((__packed__, __may_alias__)) { uint32_t x; } *u = _u;
 
         u->x = be32toh(a);
 }
 
 static inline void unaligned_write_be64(void *_u, uint64_t a) {
-        struct __attribute__((packed, may_alias)) { uint64_t x; } *u = _u;
+        struct __attribute__((__packed__, __may_alias__)) { uint64_t x; } *u = _u;
 
         u->x = be64toh(a);
 }
@@ -64,37 +64,37 @@ static inline void unaligned_write_be64(void *_u, uint64_t a) {
 /* LE */
 
 static inline uint16_t unaligned_read_le16(const void *_u) {
-        const struct __attribute__((packed, may_alias)) { uint16_t x; } *u = _u;
+        const struct __attribute__((__packed__, __may_alias__)) { uint16_t x; } *u = _u;
 
         return le16toh(u->x);
 }
 
 static inline uint32_t unaligned_read_le32(const void *_u) {
-        const struct __attribute__((packed, may_alias)) { uint32_t x; } *u = _u;
+        const struct __attribute__((__packed__, __may_alias__)) { uint32_t x; } *u = _u;
 
         return le32toh(u->x);
 }
 
 static inline uint64_t unaligned_read_le64(const void *_u) {
-        const struct __attribute__((packed, may_alias)) { uint64_t x; } *u = _u;
+        const struct __attribute__((__packed__, __may_alias__)) { uint64_t x; } *u = _u;
 
         return le64toh(u->x);
 }
 
 static inline void unaligned_write_le16(void *_u, uint16_t a) {
-        struct __attribute__((packed, may_alias)) { uint16_t x; } *u = _u;
+        struct __attribute__((__packed__, __may_alias__)) { uint16_t x; } *u = _u;
 
         u->x = le16toh(a);
 }
 
 static inline void unaligned_write_le32(void *_u, uint32_t a) {
-        struct __attribute__((packed, may_alias)) { uint32_t x; } *u = _u;
+        struct __attribute__((__packed__, __may_alias__)) { uint32_t x; } *u = _u;
 
         u->x = le32toh(a);
 }
 
 static inline void unaligned_write_le64(void *_u, uint64_t a) {
-        struct __attribute__((packed, may_alias)) { uint64_t x; } *u = _u;
+        struct __attribute__((__packed__, __may_alias__)) { uint64_t x; } *u = _u;
 
         u->x = le64toh(a);
 }

--- a/src/basic/util.h
+++ b/src/basic/util.h
@@ -127,7 +127,8 @@ static inline void _reset_errno_(int *saved_errno) {
         errno = *saved_errno;
 }
 
-#define PROTECT_ERRNO _cleanup_(_reset_errno_) __attribute__((unused)) int _saved_errno_ = errno
+#define PROTECT_ERRNO                                                   \
+        _cleanup_(_reset_errno_) __attribute__((__unused__)) int _saved_errno_ = errno
 
 static inline int negative_errno(void) {
         /* This helper should be used to shut up gcc if you know 'errno' is

--- a/src/boot/efi/meson.build
+++ b/src/boot/efi/meson.build
@@ -50,12 +50,17 @@ stub_sources = '''
 if conf.get('ENABLE_EFI') == 1 and get_option('gnu-efi') != 'false'
         efi_cc = get_option('efi-cc')
         efi_ld = get_option('efi-ld')
-
         efi_incdir = get_option('efi-includedir')
-        have_header = (gnu_efi_arch != '' and
-                       cc.has_header('@0@/@1@/efibind.h'.format(efi_incdir, gnu_efi_arch)))
 
-        if have_header and EFI_MACHINE_TYPE_NAME == ''
+        gnu_efi_path_arch = ''
+        foreach name : [gnu_efi_arch, EFI_MACHINE_TYPE_NAME]
+                if (gnu_efi_path_arch == '' and name != '' and
+                    cc.has_header('@0@/@1@/efibind.h'.format(efi_incdir, name)))
+                        gnu_efi_path_arch = name
+                endif
+        endforeach
+
+        if gnu_efi_path_arch != '' and EFI_MACHINE_TYPE_NAME == ''
                 error('gnu-efi is available, but EFI_MACHINE_TYPE_NAME is unknown')
         endif
 
@@ -68,7 +73,7 @@ if conf.get('ENABLE_EFI') == 1 and get_option('gnu-efi') != 'false'
                 endif
         endif
 
-        have_gnu_efi = have_header and efi_libdir != ''
+        have_gnu_efi = gnu_efi_path_arch != '' and efi_libdir != ''
 else
         have_gnu_efi = false
 endif
@@ -91,7 +96,7 @@ if have_gnu_efi
         objcopy = find_program('objcopy')
 
         efi_ldsdir = get_option('efi-ldsdir')
-        arch_lds = 'elf_@0@_efi.lds'.format(gnu_efi_arch)
+        arch_lds = 'elf_@0@_efi.lds'.format(gnu_efi_path_arch)
         if efi_ldsdir == ''
                 efi_ldsdir = join_paths(efi_libdir, 'gnuefi')
                 cmd = run_command('test', '-f', join_paths(efi_ldsdir, arch_lds))
@@ -121,7 +126,7 @@ if have_gnu_efi
                         '-Wsign-compare',
                         '-Wno-missing-field-initializers',
                         '-isystem', efi_incdir,
-                        '-isystem', join_paths(efi_incdir, gnu_efi_arch),
+                        '-isystem', join_paths(efi_incdir, gnu_efi_path_arch),
                         '-include', efi_config_h]
         if efi_arch == 'x86_64'
                 compile_args += ['-mno-red-zone',
@@ -141,7 +146,7 @@ if have_gnu_efi
                        '-nostdlib',
                        '-znocombreloc',
                        '-L', efi_libdir,
-                       join_paths(efi_ldsdir, 'crt0-efi-@0@.o'.format(gnu_efi_arch))]
+                       join_paths(efi_ldsdir, 'crt0-efi-@0@.o'.format(gnu_efi_path_arch))]
         if efi_arch == 'aarch64' or efi_arch == 'arm'
                 # Aarch64 and ARM32 don't have an EFI capable objcopy. Use 'binary'
                 # instead, and add required symbols manually.

--- a/src/core/dbus-execute.c
+++ b/src/core/dbus-execute.c
@@ -18,6 +18,7 @@
   along with systemd; If not, see <http://www.gnu.org/licenses/>.
 ***/
 
+#include <sys/mount.h>
 #include <sys/prctl.h>
 #include <stdio_ext.h>
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -141,7 +141,7 @@ static uint64_t arg_default_tasks_max = UINT64_MAX;
 static sd_id128_t arg_machine_id = {};
 static EmergencyAction arg_cad_burst_action = EMERGENCY_ACTION_REBOOT_FORCE;
 
-noreturn static void freeze_or_reboot(void) {
+_noreturn_ static void freeze_or_reboot(void) {
 
         if (arg_crash_reboot) {
                 log_notice("Rebooting in 10s...");
@@ -156,7 +156,7 @@ noreturn static void freeze_or_reboot(void) {
         freeze();
 }
 
-noreturn static void crash(int sig) {
+_noreturn_ static void crash(int sig) {
         struct sigaction sa;
         pid_t pid;
 

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -20,7 +20,6 @@
   along with systemd; If not, see <http://www.gnu.org/licenses/>.
 ***/
 
-#include <libmount.h>
 #include <stdbool.h>
 #include <stdio.h>
 
@@ -33,6 +32,8 @@
 #include "ip-address-access.h"
 #include "list.h"
 #include "ratelimit.h"
+
+struct libmnt_monitor;
 
 /* Enforce upper limit how many names we allow */
 #define MANAGER_MAX_NAMES 131072 /* 128K */

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -23,6 +23,8 @@
 #include <stdio.h>
 #include <sys/epoll.h>
 
+#include <libmount.h>
+
 #include "sd-messages.h"
 
 #include "alloc-util.h"

--- a/src/journal/journald-syslog.c
+++ b/src/journal/journald-syslog.c
@@ -237,7 +237,7 @@ size_t syslog_parse_identifier(const char **buf, char **identifier, char **pid) 
         if (t)
                 *identifier = t;
 
-        if (strchr(WHITESPACE, p[e]))
+        if (p[e] != '\0' && strchr(WHITESPACE, p[e]))
                 e++;
         *buf = p + e;
         return e;

--- a/src/journal/test-journal-interleaving.c
+++ b/src/journal/test-journal-interleaving.c
@@ -37,7 +37,7 @@
 
 static bool arg_keep = false;
 
-noreturn static void log_assert_errno(const char *text, int error, const char *file, int line, const char *func) {
+_noreturn_ static void log_assert_errno(const char *text, int error, const char *file, int line, const char *func) {
         log_internal(LOG_CRIT, error, file, line, func,
                      "'%s' failed at %s:%u (%s): %m", text, file, line, func);
         abort();

--- a/src/journal/test-journal-syslog.c
+++ b/src/journal/test-journal-syslog.c
@@ -23,8 +23,8 @@
 #include "macro.h"
 #include "string-util.h"
 
-static void test_syslog_parse_identifier(const char* str,
-                                         const char *ident, const char*pid, int ret) {
+static void test_syslog_parse_identifier(const char *str,
+                                         const char *ident, const char *pid, const char *rest, int ret) {
         const char *buf = str;
         _cleanup_free_ char *ident2 = NULL, *pid2 = NULL;
         int ret2;
@@ -34,12 +34,22 @@ static void test_syslog_parse_identifier(const char* str,
         assert_se(ret == ret2);
         assert_se(ident == ident2 || streq_ptr(ident, ident2));
         assert_se(pid == pid2 || streq_ptr(pid, pid2));
+        assert_se(streq(buf, rest));
 }
 
 int main(void) {
-        test_syslog_parse_identifier("pidu[111]: xxx", "pidu", "111", 11);
-        test_syslog_parse_identifier("pidu: xxx", "pidu", NULL, 6);
-        test_syslog_parse_identifier("pidu xxx", NULL, NULL, 0);
+        test_syslog_parse_identifier("pidu[111]: xxx", "pidu", "111", "xxx", 11);
+        test_syslog_parse_identifier("pidu: xxx", "pidu", NULL, "xxx", 6);
+        test_syslog_parse_identifier("pidu:  xxx", "pidu", NULL, " xxx", 6);
+        test_syslog_parse_identifier("pidu xxx", NULL, NULL, "pidu xxx", 0);
+        test_syslog_parse_identifier("   pidu xxx", NULL, NULL, "   pidu xxx", 0);
+        test_syslog_parse_identifier("", NULL, NULL, "", 0);
+        test_syslog_parse_identifier("  ", NULL, NULL, "  ", 0);
+        test_syslog_parse_identifier(":", "", NULL, "", 1);
+        test_syslog_parse_identifier(":  ", "", NULL, " ", 2);
+        test_syslog_parse_identifier("pidu:", "pidu", NULL, "", 5);
+        test_syslog_parse_identifier("pidu: ", "pidu", NULL, "", 6);
+        test_syslog_parse_identifier("pidu : ", NULL, NULL, "pidu : ", 0);
 
         return 0;
 }

--- a/src/libsystemd/sd-bus/bus-error.h
+++ b/src/libsystemd/sd-bus/bus-error.h
@@ -52,11 +52,12 @@ int bus_error_set_errnofv(sd_bus_error *e, int error, const char *format, va_lis
 #define BUS_ERROR_MAP_ELF_REGISTER                                      \
         __attribute__ ((__section__("BUS_ERROR_MAP")))                  \
         __attribute__ ((__used__))                                      \
-        __attribute__ ((aligned(8)))
+        __attribute__ ((__aligned__(8)))
 
 #define BUS_ERROR_MAP_ELF_USE(errors)                                   \
         extern const sd_bus_error_map errors[];                         \
-        __attribute__ ((used)) static const sd_bus_error_map * const CONCATENATE(errors ## _copy_, __COUNTER__) = errors;
+        __attribute__ ((__used__))                                      \
+        static const sd_bus_error_map * const CONCATENATE(errors ## _copy_, __COUNTER__) = errors;
 
 /* We use something exotic as end marker, to ensure people build the
  * maps using the macsd-ros. */

--- a/src/libudev/libudev.h
+++ b/src/libudev/libudev.h
@@ -42,9 +42,9 @@ struct udev *udev_new(void);
 void udev_set_log_fn(struct udev *udev,
                             void (*log_fn)(struct udev *udev,
                                            int priority, const char *file, int line, const char *fn,
-                                           const char *format, va_list args)) __attribute__ ((deprecated));
-int udev_get_log_priority(struct udev *udev) __attribute__ ((deprecated));
-void udev_set_log_priority(struct udev *udev, int priority) __attribute__ ((deprecated));
+                                           const char *format, va_list args)) __attribute__((__deprecated__));
+int udev_get_log_priority(struct udev *udev) __attribute__((__deprecated__));
+void udev_set_log_priority(struct udev *udev, int priority) __attribute__((__deprecated__));
 void *udev_get_userdata(struct udev *udev);
 void udev_set_userdata(struct udev *udev, void *userdata);
 
@@ -171,16 +171,16 @@ struct udev_queue *udev_queue_ref(struct udev_queue *udev_queue);
 struct udev_queue *udev_queue_unref(struct udev_queue *udev_queue);
 struct udev *udev_queue_get_udev(struct udev_queue *udev_queue);
 struct udev_queue *udev_queue_new(struct udev *udev);
-unsigned long long int udev_queue_get_kernel_seqnum(struct udev_queue *udev_queue) __attribute__ ((deprecated));
-unsigned long long int udev_queue_get_udev_seqnum(struct udev_queue *udev_queue) __attribute__ ((deprecated));
+unsigned long long int udev_queue_get_kernel_seqnum(struct udev_queue *udev_queue) __attribute__((__deprecated__));
+        unsigned long long int udev_queue_get_udev_seqnum(struct udev_queue *udev_queue) __attribute__((__deprecated__));
 int udev_queue_get_udev_is_active(struct udev_queue *udev_queue);
 int udev_queue_get_queue_is_empty(struct udev_queue *udev_queue);
-int udev_queue_get_seqnum_is_finished(struct udev_queue *udev_queue, unsigned long long int seqnum) __attribute__ ((deprecated));
+int udev_queue_get_seqnum_is_finished(struct udev_queue *udev_queue, unsigned long long int seqnum) __attribute__((__deprecated__));
 int udev_queue_get_seqnum_sequence_is_finished(struct udev_queue *udev_queue,
-                                               unsigned long long int start, unsigned long long int end) __attribute__ ((deprecated));
+                                               unsigned long long int start, unsigned long long int end) __attribute__((__deprecated__));
 int udev_queue_get_fd(struct udev_queue *udev_queue);
 int udev_queue_flush(struct udev_queue *udev_queue);
-struct udev_list_entry *udev_queue_get_queued_list_entry(struct udev_queue *udev_queue) __attribute__ ((deprecated));
+struct udev_list_entry *udev_queue_get_queued_list_entry(struct udev_queue *udev_queue) __attribute__((__deprecated__));
 
 /*
  *  udev_hwdb

--- a/src/shared/pager.c
+++ b/src/shared/pager.c
@@ -47,7 +47,7 @@ static int stored_stderr = -1;
 static bool stdout_redirected = false;
 static bool stderr_redirected = false;
 
-noreturn static void pager_fallback(void) {
+_noreturn_ static void pager_fallback(void) {
         int r;
 
         r = copy_bytes(STDIN_FILENO, STDOUT_FILENO, (uint64_t) -1, 0);

--- a/src/systemd/_sd-common.h
+++ b/src/systemd/_sd-common.h
@@ -29,22 +29,22 @@
 
 #ifndef _sd_printf_
 #  if __GNUC__ >= 4
-#    define _sd_printf_(a,b) __attribute__ ((format (printf, a, b)))
+#    define _sd_printf_(a,b) __attribute__ ((__format__(printf, a, b)))
 #  else
 #    define _sd_printf_(a,b)
 #  endif
 #endif
 
 #ifndef _sd_sentinel_
-#  define _sd_sentinel_ __attribute__((sentinel))
+#  define _sd_sentinel_ __attribute__((__sentinel__))
 #endif
 
 #ifndef _sd_packed_
-#  define _sd_packed_ __attribute__((packed))
+#  define _sd_packed_ __attribute__((__packed__))
 #endif
 
 #ifndef _sd_pure_
-#  define _sd_pure_ __attribute__((pure))
+#  define _sd_pure_ __attribute__((__pure__))
 #endif
 
 #ifndef _SD_STRINGIFY

--- a/src/test/test-parse-util.c
+++ b/src/test/test-parse-util.c
@@ -468,6 +468,44 @@ static void test_safe_atoi16(void) {
         assert_se(r == -EINVAL);
 }
 
+static void test_safe_atoux16(void) {
+        int r;
+        uint16_t l;
+
+        r = safe_atoux16("1234", &l);
+        assert_se(r == 0);
+        assert_se(l == 0x1234);
+
+        r = safe_atoux16("abcd", &l);
+        assert_se(r == 0);
+        assert_se(l == 0xabcd);
+
+        r = safe_atoux16("  1234", &l);
+        assert_se(r == 0);
+        assert_se(l == 0x1234);
+
+        r = safe_atoux16("12345", &l);
+        assert_se(r == -ERANGE);
+
+        r = safe_atoux16("-1", &l);
+        assert_se(r == -ERANGE);
+
+        r = safe_atoux16("  -1", &l);
+        assert_se(r == -ERANGE);
+
+        r = safe_atoux16("junk", &l);
+        assert_se(r == -EINVAL);
+
+        r = safe_atoux16("123x", &l);
+        assert_se(r == -EINVAL);
+
+        r = safe_atoux16("12.3", &l);
+        assert_se(r == -EINVAL);
+
+        r = safe_atoux16("", &l);
+        assert_se(r == -EINVAL);
+}
+
 static void test_safe_atou64(void) {
         int r;
         uint64_t l;
@@ -745,6 +783,7 @@ int main(int argc, char *argv[]) {
         test_safe_atolli();
         test_safe_atou16();
         test_safe_atoi16();
+        test_safe_atoux16();
         test_safe_atou64();
         test_safe_atoi64();
         test_safe_atod();

--- a/src/udev/collect/collect.c
+++ b/src/udev/collect/collect.c
@@ -58,7 +58,7 @@ static inline struct _mate *node_to_mate(struct udev_list_node *node)
         return container_of(node, struct _mate, node);
 }
 
-noreturn static void sig_alrm(int signo)
+_noreturn_ static void sig_alrm(int signo)
 {
         exit(4);
 }

--- a/src/udev/udev-builtin-hwdb.c
+++ b/src/udev/udev-builtin-hwdb.c
@@ -27,6 +27,7 @@
 
 #include "alloc-util.h"
 #include "hwdb-util.h"
+#include "parse-util.h"
 #include "string-util.h"
 #include "udev-util.h"
 #include "udev.h"
@@ -63,7 +64,7 @@ int udev_builtin_hwdb_lookup(struct udev_device *dev,
 
 static const char *modalias_usb(struct udev_device *dev, char *s, size_t size) {
         const char *v, *p;
-        int vn, pn;
+        uint16_t vn, pn;
 
         v = udev_device_get_sysattr_value(dev, "idVendor");
         if (!v)
@@ -71,12 +72,10 @@ static const char *modalias_usb(struct udev_device *dev, char *s, size_t size) {
         p = udev_device_get_sysattr_value(dev, "idProduct");
         if (!p)
                 return NULL;
-        vn = strtol(v, NULL, 16);
-        if (vn <= 0)
-                return NULL;
-        pn = strtol(p, NULL, 16);
-        if (pn <= 0)
-                return NULL;
+        if (safe_atoux16(v, &vn) < 0)
+		return NULL;
+        if (safe_atoux16(p, &pn) < 0)
+		return NULL;
         snprintf(s, size, "usb:v%04Xp%04X*", vn, pn);
         return s;
 }


### PR DESCRIPTION
This is a series of cherry-picks of recent commits that went in after v237 and that enable systemd to build with a more recent toolchain.

The most notable are the issue with Meson's `-Ddebug` which had to be renamed to `-Ddebug-extra`, the issue with `noreturn` which turned into `__noreturn__` and the issue with `MS_MOVE` getting multiple definitions.

These *should* be safe with the older toolchains. While they enable build with newer toolchains, older ones should still work... But I haven't really tested with those, so it's quite possible something will break... Also, at least the Meson change renaming the option (`-Ddebug-extra`) is not backwards-compatible, so it will break a build that is using it...

Some of these are unfortunately somewhat more invasive... But they've been in the tree for quite a while, so maybe it's OK to backport?

This was useful for me to test #19, so I thought maybe I should send this as a PR. This is on top of #19, so I suggest merging that one first and then potentially having some discussion on this one.

If you're against merging this, I completely agree... In that case, I'd like to find a better development environment to testing backports on these older stable branches (perhaps building under `mock` or a container would be more appropriate... suggestions?)

Cheers,
Filipe
