### PR TITLE
Fix out-of-bounds read (CVE-2018-16866)

### DIFF
--- a/src/journal/journald-syslog.c
+++ b/src/journal/journald-syslog.c
@@ -239,7 +239,7 @@ size_t syslog_parse_identifier(const char **buf, char **identifier, char **pid) 
         if (t)
                 *identifier = t;
 
-        if (strchr(WHITESPACE, p[e]))
+        if (p[e] != '\0' && strchr(WHITESPACE, p[e]))
                 e++;
         *buf = p + e;
         return e;

--- a/src/journal/test-journal-syslog.c
+++ b/src/journal/test-journal-syslog.c
@@ -22,8 +22,8 @@
 #include "macro.h"
 #include "string-util.h"
 
-static void test_syslog_parse_identifier(const char* str,
-                                         const char *ident, const char*pid, int ret) {
+static void test_syslog_parse_identifier(const char *str,
+                                         const char *ident, const char *pid, const char *rest, int ret) {
         const char *buf = str;
         _cleanup_free_ char *ident2 = NULL, *pid2 = NULL;
         int ret2;
@@ -33,12 +33,22 @@ static void test_syslog_parse_identifier(const char* str,
         assert_se(ret == ret2);
         assert_se(ident == ident2 || streq_ptr(ident, ident2));
         assert_se(pid == pid2 || streq_ptr(pid, pid2));
+        assert_se(streq(buf, rest));
 }
 
 int main(void) {
-        test_syslog_parse_identifier("pidu[111]: xxx", "pidu", "111", 11);
-        test_syslog_parse_identifier("pidu: xxx", "pidu", NULL, 6);
-        test_syslog_parse_identifier("pidu xxx", NULL, NULL, 0);
+        test_syslog_parse_identifier("pidu[111]: xxx", "pidu", "111", "xxx", 11);
+        test_syslog_parse_identifier("pidu: xxx", "pidu", NULL, "xxx", 6);
+        test_syslog_parse_identifier("pidu:  xxx", "pidu", NULL, " xxx", 6);
+        test_syslog_parse_identifier("pidu xxx", NULL, NULL, "pidu xxx", 0);
+        test_syslog_parse_identifier("   pidu xxx", NULL, NULL, "   pidu xxx", 0);
+        test_syslog_parse_identifier("", NULL, NULL, "", 0);
+        test_syslog_parse_identifier("  ", NULL, NULL, "  ", 0);
+        test_syslog_parse_identifier(":", "", NULL, "", 1);
+        test_syslog_parse_identifier(":  ", "", NULL, " ", 2);
+        test_syslog_parse_identifier("pidu:", "pidu", NULL, "", 5);
+        test_syslog_parse_identifier("pidu: ", "pidu", NULL, "", 6);
+        test_syslog_parse_identifier("pidu : ", NULL, NULL, "pidu : ", 0);
 
         return 0;
 }


### PR DESCRIPTION
Same as #15, for v229.

Tested locally, this uses automake so Semaphore won't like it. I have a branch with the fixes to the build system, will send those as a follow up later on.

This is the last branch in systemd-stable which was affected by this CVE, so after these last 3 PRs are in, all the branches in systemd-stable should no longer be vulnerable.

/cc @keszybz