### PR TITLE
Cherry-picks for build fixes, to build v229 on a modern toolchain (still using automake though)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,6 +254,28 @@ AC_CHECK_SIZEOF(rlim_t,,[
        #include <sys/resource.h>
 ])
 
+GPERF_TEST="$(echo foo,bar | ${GPERF} -L ANSI-C)"
+
+AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([
+                #include <string.h>
+                const char * in_word_set(const char *, size_t);
+                $GPERF_TEST]
+        )],
+        [GPERF_LEN_TYPE=size_t],
+        [AC_COMPILE_IFELSE(
+                [AC_LANG_PROGRAM([
+                        #include <string.h>
+                        const char * in_word_set(const char *, unsigned);
+                        $GPERF_TEST]
+                )],
+                [GPERF_LEN_TYPE=unsigned],
+                [AC_MSG_ERROR([** unable to determine gperf len type])]
+        )]
+)
+
+AC_DEFINE_UNQUOTED([GPERF_LEN_TYPE], [$GPERF_LEN_TYPE], [gperf len type])
+
 # ------------------------------------------------------------------------------
 # we use python to build the man page index
 have_python=no

--- a/src/basic/af-list.c
+++ b/src/basic/af-list.c
@@ -23,7 +23,7 @@
 #include "af-list.h"
 #include "macro.h"
 
-static const struct af_name* lookup_af(register const char *str, register unsigned int len);
+static const struct af_name* lookup_af(register const char *str, register GPERF_LEN_TYPE len);
 
 #include "af-from-name.h"
 #include "af-to-name.h"

--- a/src/basic/arphrd-list.c
+++ b/src/basic/arphrd-list.c
@@ -23,7 +23,7 @@
 #include "arphrd-list.h"
 #include "macro.h"
 
-static const struct arphrd_name* lookup_arphrd(register const char *str, register unsigned int len);
+static const struct arphrd_name* lookup_arphrd(register const char *str, register GPERF_LEN_TYPE len);
 
 #include "arphrd-from-name.h"
 #include "arphrd-to-name.h"

--- a/src/basic/cap-list.c
+++ b/src/basic/cap-list.c
@@ -26,7 +26,7 @@
 #include "parse-util.h"
 #include "util.h"
 
-static const struct capability_name* lookup_capability(register const char *str, register unsigned int len);
+static const struct capability_name* lookup_capability(register const char *str, register GPERF_LEN_TYPE len);
 
 #include "cap-from-name.h"
 #include "cap-to-name.h"

--- a/src/basic/errno-list.c
+++ b/src/basic/errno-list.c
@@ -23,7 +23,7 @@
 #include "macro.h"
 
 static const struct errno_name* lookup_errno(register const char *str,
-                                             register unsigned int len);
+                                             register GPERF_LEN_TYPE len);
 
 #include "errno-from-name.h"
 #include "errno-to-name.h"

--- a/src/basic/log.c
+++ b/src/basic/log.c
@@ -783,12 +783,12 @@ static void log_assert(
         log_dispatch(level, 0, file, line, func, NULL, NULL, buffer);
 }
 
-noreturn void log_assert_failed(const char *text, const char *file, int line, const char *func) {
+_noreturn_ void log_assert_failed(const char *text, const char *file, int line, const char *func) {
         log_assert(LOG_CRIT, text, file, line, func, "Assertion '%s' failed at %s:%u, function %s(). Aborting.");
         abort();
 }
 
-noreturn void log_assert_failed_unreachable(const char *text, const char *file, int line, const char *func) {
+_noreturn_ void log_assert_failed_unreachable(const char *text, const char *file, int line, const char *func) {
         log_assert(LOG_CRIT, text, file, line, func, "Code should not be reached '%s' at %s:%u, function %s(). Aborting.");
         abort();
 }

--- a/src/basic/log.h
+++ b/src/basic/log.h
@@ -145,13 +145,13 @@ int log_dump_internal(
                 char *buffer);
 
 /* Logging for various assertions */
-noreturn void log_assert_failed(
+_noreturn_ void log_assert_failed(
                 const char *text,
                 const char *file,
                 int line,
                 const char *func);
 
-noreturn void log_assert_failed_unreachable(
+_noreturn_ void log_assert_failed_unreachable(
                 const char *text,
                 const char *file,
                 int line,

--- a/src/basic/macro.h
+++ b/src/basic/macro.h
@@ -23,6 +23,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <sys/param.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 
 #define _printf_(a,b) __attribute__ ((format (printf, a, b)))

--- a/src/basic/macro.h
+++ b/src/basic/macro.h
@@ -26,31 +26,31 @@
 #include <sys/sysmacros.h>
 #include <sys/types.h>
 
-#define _printf_(a,b) __attribute__ ((format (printf, a, b)))
-#define _alloc_(...) __attribute__ ((alloc_size(__VA_ARGS__)))
-#define _sentinel_ __attribute__ ((sentinel))
-#define _unused_ __attribute__ ((unused))
-#define _destructor_ __attribute__ ((destructor))
-#define _pure_ __attribute__ ((pure))
-#define _const_ __attribute__ ((const))
-#define _deprecated_ __attribute__ ((deprecated))
-#define _packed_ __attribute__ ((packed))
-#define _malloc_ __attribute__ ((malloc))
-#define _weak_ __attribute__ ((weak))
+#define _printf_(a,b) __attribute__ ((__format__ (printf, a, b)))
+#define _alloc_(...) __attribute__ ((__alloc_size__(__VA_ARGS__)))
+#define _sentinel_ __attribute__ ((__sentinel__))
+#define _unused_ __attribute__ ((__unused__))
+#define _destructor_ __attribute__ ((__destructor__))
+#define _pure_ __attribute__ ((__pure__))
+#define _const_ __attribute__ ((__const__))
+#define _deprecated_ __attribute__ ((__deprecated__))
+#define _packed_ __attribute__ ((__packed__))
+#define _malloc_ __attribute__ ((__malloc__))
+#define _weak_ __attribute__ ((__weak__))
 #define _likely_(x) (__builtin_expect(!!(x),1))
 #define _unlikely_(x) (__builtin_expect(!!(x),0))
-#define _public_ __attribute__ ((visibility("default")))
-#define _hidden_ __attribute__ ((visibility("hidden")))
-#define _weakref_(x) __attribute__((weakref(#x)))
-#define _alignas_(x) __attribute__((aligned(__alignof(x))))
-#define _cleanup_(x) __attribute__((cleanup(x)))
+#define _public_ __attribute__ ((__visibility__("default")))
+#define _hidden_ __attribute__ ((__visibility__("hidden")))
+#define _weakref_(x) __attribute__((__weakref__(#x)))
+#define _alignas_(x) __attribute__((__aligned__(__alignof(x))))
+#define _cleanup_(x) __attribute__((__cleanup__(x)))
 /* Define C11 noreturn without <stdnoreturn.h> and even on older gcc
  * compiler versions */
 #ifndef _noreturn_
 #if __STDC_VERSION__ >= 201112L
 #define _noreturn_ _Noreturn
 #else
-#define _noreturn_ __attribute__((noreturn))
+#define _noreturn_ __attribute__((__noreturn__))
 #endif
 #endif
 

--- a/src/basic/macro.h
+++ b/src/basic/macro.h
@@ -44,6 +44,15 @@
 #define _weakref_(x) __attribute__((weakref(#x)))
 #define _alignas_(x) __attribute__((aligned(__alignof(x))))
 #define _cleanup_(x) __attribute__((cleanup(x)))
+/* Define C11 noreturn without <stdnoreturn.h> and even on older gcc
+ * compiler versions */
+#ifndef _noreturn_
+#if __STDC_VERSION__ >= 201112L
+#define _noreturn_ _Noreturn
+#else
+#define _noreturn_ __attribute__((noreturn))
+#endif
+#endif
 
 /* Temporarily disable some warnings */
 #define DISABLE_WARNING_DECLARATION_AFTER_STATEMENT                     \
@@ -379,16 +388,6 @@ static inline unsigned long ALIGN_POWER2(unsigned long u) {
 #define thread_local _Thread_local
 #else
 #define thread_local __thread
-#endif
-#endif
-
-/* Define C11 noreturn without <stdnoreturn.h> and even on older gcc
- * compiler versions */
-#ifndef noreturn
-#if __STDC_VERSION__ >= 201112L
-#define noreturn _Noreturn
-#else
-#define noreturn __attribute__((noreturn))
 #endif
 #endif
 

--- a/src/basic/missing.h
+++ b/src/basic/missing.h
@@ -135,9 +135,11 @@
 #endif
 
 #if !HAVE_DECL_PIVOT_ROOT
-static inline int pivot_root(const char *new_root, const char *put_old) {
+static inline int missing_pivot_root(const char *new_root, const char *put_old) {
         return syscall(SYS_pivot_root, new_root, put_old);
 }
+
+#  define pivot_root missing_pivot_root
 #endif
 
 #ifndef __NR_memfd_create
@@ -168,9 +170,11 @@ static inline int pivot_root(const char *new_root, const char *put_old) {
 #endif
 
 #ifndef HAVE_MEMFD_CREATE
-static inline int memfd_create(const char *name, unsigned int flags) {
+static inline int missing_memfd_create(const char *name, unsigned int flags) {
         return syscall(__NR_memfd_create, name, flags);
 }
+
+#  define memfd_create missing_memfd_create
 #endif
 
 #ifndef __NR_getrandom
@@ -207,9 +211,11 @@ static inline int memfd_create(const char *name, unsigned int flags) {
 #endif
 
 #if !HAVE_DECL_GETRANDOM
-static inline int getrandom(void *buffer, size_t count, unsigned flags) {
+static inline int missing_getrandom(void *buffer, size_t count, unsigned flags) {
         return syscall(__NR_getrandom, buffer, count, flags);
 }
+
+#  define getrandom missing_getrandom
 #endif
 
 #ifndef GRND_NONBLOCK
@@ -527,9 +533,11 @@ struct btrfs_ioctl_quota_ctl_args {
 #endif
 
 #if !HAVE_DECL_GETTID
-static inline pid_t gettid(void) {
+static inline pid_t missing_gettid(void) {
         return (pid_t) syscall(SYS_gettid);
 }
+
+#  define gettid missing_gettid
 #endif
 
 #ifndef SCM_SECURITY
@@ -581,9 +589,11 @@ struct file_handle {
         unsigned char f_handle[0];
 };
 
-static inline int name_to_handle_at(int fd, const char *name, struct file_handle *handle, int *mnt_id, int flags) {
+static inline int missing_name_to_handle_at(int fd, const char *name, struct file_handle *handle, int *mnt_id, int flags) {
         return syscall(__NR_name_to_handle_at, fd, name, handle, mnt_id, flags);
 }
+
+#  define name_to_handle_at missing_name_to_handle_at
 #endif
 
 #ifndef HAVE_SECURE_GETENV
@@ -645,9 +655,11 @@ static inline int name_to_handle_at(int fd, const char *name, struct file_handle
 #endif
 
 #if !HAVE_DECL_SETNS
-static inline int setns(int fd, int nstype) {
+static inline int missing_setns(int fd, int nstype) {
         return syscall(__NR_setns, fd, nstype);
 }
+
+#  define setns missing_setns
 #endif
 
 #if !HAVE_DECL_LO_FLAGS_PARTSCAN
@@ -1060,9 +1072,11 @@ static inline pid_t raw_getpid(void) {
 #  endif
 #endif
 
-static inline int renameat2(int oldfd, const char *oldname, int newfd, const char *newname, unsigned flags) {
+static inline int missing_renameat2(int oldfd, const char *oldname, int newfd, const char *newname, unsigned flags) {
         return syscall(__NR_renameat2, oldfd, oldname, newfd, newname, flags);
 }
+
+#  define renameat2 missing_renameat2
 #endif
 
 #ifndef RENAME_NOREPLACE
@@ -1070,7 +1084,7 @@ static inline int renameat2(int oldfd, const char *oldname, int newfd, const cha
 #endif
 
 #if !HAVE_DECL_KCMP
-static inline int kcmp(pid_t pid1, pid_t pid2, int type, unsigned long idx1, unsigned long idx2) {
+static inline int missing_kcmp(pid_t pid1, pid_t pid2, int type, unsigned long idx1, unsigned long idx2) {
 #if defined(__NR_kcmp)
         return syscall(__NR_kcmp, pid1, pid2, type, idx1, idx2);
 #else
@@ -1078,6 +1092,8 @@ static inline int kcmp(pid_t pid1, pid_t pid2, int type, unsigned long idx1, uns
         return -1;
 #endif
 }
+
+#  define kcmp missing_kcmp
 #endif
 
 #ifndef KCMP_FILE
@@ -1097,7 +1113,7 @@ typedef int32_t key_serial_t;
 #endif
 
 #if !HAVE_DECL_KEYCTL
-static inline long keyctl(int cmd, unsigned long arg2, unsigned long arg3, unsigned long arg4,unsigned long arg5) {
+static inline long missing_keyctl(int cmd, unsigned long arg2, unsigned long arg3, unsigned long arg4,unsigned long arg5) {
 #if defined(__NR_keyctl)
         return syscall(__NR_keyctl, cmd, arg2, arg3, arg4, arg5);
 #else
@@ -1106,7 +1122,9 @@ static inline long keyctl(int cmd, unsigned long arg2, unsigned long arg3, unsig
 #endif
 }
 
-static inline key_serial_t add_key(const char *type, const char *description, const void *payload, size_t plen, key_serial_t ringid) {
+#  define keyctl missing_keyctl
+
+static inline key_serial_t missing_add_key(const char *type, const char *description, const void *payload, size_t plen, key_serial_t ringid) {
 #if defined (__NR_add_key)
         return syscall(__NR_add_key, type, description, payload, plen, ringid);
 #else
@@ -1115,7 +1133,9 @@ static inline key_serial_t add_key(const char *type, const char *description, co
 #endif
 }
 
-static inline key_serial_t request_key(const char *type, const char *description, const char * callout_info, key_serial_t destringid) {
+#  define add_key missing_add_key
+
+static inline key_serial_t missing_request_key(const char *type, const char *description, const char * callout_info, key_serial_t destringid) {
 #if defined (__NR_request_key)
         return syscall(__NR_request_key, type, description, callout_info, destringid);
 #else
@@ -1123,6 +1143,8 @@ static inline key_serial_t request_key(const char *type, const char *description
         return -1;
 #endif
 }
+
+#  define request_key missing_request_key
 #endif
 
 #ifndef KEYCTL_READ

--- a/src/basic/parse-util.c
+++ b/src/basic/parse-util.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <xlocale.h>
 
 #include "alloc-util.h"
 #include "extract-word.h"

--- a/src/basic/parse-util.c
+++ b/src/basic/parse-util.c
@@ -468,6 +468,30 @@ int safe_atoi16(const char *s, int16_t *ret) {
         return 0;
 }
 
+int safe_atoux16(const char *s, uint16_t *ret) {
+        char *x = NULL;
+        unsigned long l;
+
+        assert(s);
+        assert(ret);
+
+        s += strspn(s, WHITESPACE);
+
+        errno = 0;
+        l = strtoul(s, &x, 16);
+        if (errno > 0)
+                return -errno;
+        if (!x || x == s || *x != 0)
+                return -EINVAL;
+        if (s[0] == '-')
+                return -ERANGE;
+        if ((unsigned long) (uint16_t) l != l)
+                return -ERANGE;
+
+        *ret = (uint16_t) l;
+        return 0;
+}
+
 int safe_atod(const char *s, double *ret_d) {
         char *x = NULL;
         double d = 0;

--- a/src/basic/parse-util.h
+++ b/src/basic/parse-util.h
@@ -50,6 +50,8 @@ int safe_atou8(const char *s, uint8_t *ret);
 int safe_atou16(const char *s, uint16_t *ret);
 int safe_atoi16(const char *s, int16_t *ret);
 
+int safe_atoux16(const char *s, uint16_t *ret);
+
 static inline int safe_atou32(const char *s, uint32_t *ret_u) {
         assert_cc(sizeof(uint32_t) == sizeof(unsigned));
         return safe_atou(s, (unsigned*) ret_u);

--- a/src/basic/process-util.c
+++ b/src/basic/process-util.c
@@ -658,7 +658,7 @@ bool is_main_thread(void) {
         return cached > 0;
 }
 
-noreturn void freeze(void) {
+_noreturn_ void freeze(void) {
 
         /* Make sure nobody waits for us on a socket anymore */
         close_all_fds(NULL, 0);

--- a/src/basic/process-util.h
+++ b/src/basic/process-util.h
@@ -74,7 +74,7 @@ int pid_from_same_root_fs(pid_t pid);
 
 bool is_main_thread(void);
 
-noreturn void freeze(void);
+_noreturn_ void freeze(void);
 
 bool oom_score_adjust_is_valid(int oa);
 

--- a/src/basic/sparse-endian.h
+++ b/src/basic/sparse-endian.h
@@ -26,19 +26,19 @@
 #include <stdint.h>
 
 #ifdef __CHECKER__
-#define __bitwise __attribute__((bitwise))
-#define __force __attribute__((force))
+#define __sd_bitwise __attribute__((bitwise))
+#define __sd_force __attribute__((force))
 #else
-#define __bitwise
-#define __force
+#define __sd_bitwise
+#define __sd_force
 #endif
 
-typedef uint16_t __bitwise le16_t;
-typedef uint16_t __bitwise be16_t;
-typedef uint32_t __bitwise le32_t;
-typedef uint32_t __bitwise be32_t;
-typedef uint64_t __bitwise le64_t;
-typedef uint64_t __bitwise be64_t;
+typedef uint16_t __sd_bitwise le16_t;
+typedef uint16_t __sd_bitwise be16_t;
+typedef uint32_t __sd_bitwise le32_t;
+typedef uint32_t __sd_bitwise be32_t;
+typedef uint64_t __sd_bitwise le64_t;
+typedef uint64_t __sd_bitwise be64_t;
 
 #undef htobe16
 #undef htole16
@@ -69,20 +69,23 @@ typedef uint64_t __bitwise be64_t;
 #define bswap_64_on_be(x) __bswap_64(x)
 #endif
 
-static inline le16_t htole16(uint16_t value) { return (le16_t __force) bswap_16_on_be(value); }
-static inline le32_t htole32(uint32_t value) { return (le32_t __force) bswap_32_on_be(value); }
-static inline le64_t htole64(uint64_t value) { return (le64_t __force) bswap_64_on_be(value); }
+static inline le16_t htole16(uint16_t value) { return (le16_t __sd_force) bswap_16_on_be(value); }
+static inline le32_t htole32(uint32_t value) { return (le32_t __sd_force) bswap_32_on_be(value); }
+static inline le64_t htole64(uint64_t value) { return (le64_t __sd_force) bswap_64_on_be(value); }
 
-static inline be16_t htobe16(uint16_t value) { return (be16_t __force) bswap_16_on_le(value); }
-static inline be32_t htobe32(uint32_t value) { return (be32_t __force) bswap_32_on_le(value); }
-static inline be64_t htobe64(uint64_t value) { return (be64_t __force) bswap_64_on_le(value); }
+static inline be16_t htobe16(uint16_t value) { return (be16_t __sd_force) bswap_16_on_le(value); }
+static inline be32_t htobe32(uint32_t value) { return (be32_t __sd_force) bswap_32_on_le(value); }
+static inline be64_t htobe64(uint64_t value) { return (be64_t __sd_force) bswap_64_on_le(value); }
 
-static inline uint16_t le16toh(le16_t value) { return bswap_16_on_be((uint16_t __force)value); }
-static inline uint32_t le32toh(le32_t value) { return bswap_32_on_be((uint32_t __force)value); }
-static inline uint64_t le64toh(le64_t value) { return bswap_64_on_be((uint64_t __force)value); }
+static inline uint16_t le16toh(le16_t value) { return bswap_16_on_be((uint16_t __sd_force)value); }
+static inline uint32_t le32toh(le32_t value) { return bswap_32_on_be((uint32_t __sd_force)value); }
+static inline uint64_t le64toh(le64_t value) { return bswap_64_on_be((uint64_t __sd_force)value); }
 
-static inline uint16_t be16toh(be16_t value) { return bswap_16_on_le((uint16_t __force)value); }
-static inline uint32_t be32toh(be32_t value) { return bswap_32_on_le((uint32_t __force)value); }
-static inline uint64_t be64toh(be64_t value) { return bswap_64_on_le((uint64_t __force)value); }
+static inline uint16_t be16toh(be16_t value) { return bswap_16_on_le((uint16_t __sd_force)value); }
+static inline uint32_t be32toh(be32_t value) { return bswap_32_on_le((uint32_t __sd_force)value); }
+static inline uint64_t be64toh(be64_t value) { return bswap_64_on_le((uint64_t __sd_force)value); }
+
+#undef __sd_bitwise
+#undef __sd_force
 
 #endif /* SPARSE_ENDIAN_H */

--- a/src/basic/sparse-endian.h
+++ b/src/basic/sparse-endian.h
@@ -26,8 +26,8 @@
 #include <stdint.h>
 
 #ifdef __CHECKER__
-#define __sd_bitwise __attribute__((bitwise))
-#define __sd_force __attribute__((force))
+#define __sd_bitwise __attribute__((__bitwise__))
+#define __sd_force __attribute__((__force__))
 #else
 #define __sd_bitwise
 #define __sd_force

--- a/src/basic/stdio-util.h
+++ b/src/basic/stdio-util.h
@@ -26,9 +26,11 @@
 
 #include "macro.h"
 
-#define xsprintf(buf, fmt, ...) \
-        assert_message_se((size_t) snprintf(buf, ELEMENTSOF(buf), fmt, __VA_ARGS__) < ELEMENTSOF(buf), "xsprintf: " #buf "[] must be big enough")
+#define snprintf_ok(buf, len, fmt, ...) \
+        ((size_t) snprintf(buf, len, fmt, __VA_ARGS__) < (len))
 
+#define xsprintf(buf, fmt, ...) \
+        assert_message_se(snprintf_ok(buf, ELEMENTSOF(buf), fmt, __VA_ARGS__), "xsprintf: " #buf "[] must be big enough")
 
 #define VA_FORMAT_ADVANCE(format, ap)                                   \
 do {                                                                    \

--- a/src/basic/util.h
+++ b/src/basic/util.h
@@ -36,6 +36,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>

--- a/src/basic/util.h
+++ b/src/basic/util.h
@@ -117,7 +117,8 @@ static inline void _reset_errno_(int *saved_errno) {
         errno = *saved_errno;
 }
 
-#define PROTECT_ERRNO _cleanup_(_reset_errno_) __attribute__((unused)) int _saved_errno_ = errno
+#define PROTECT_ERRNO                                                   \
+        _cleanup_(_reset_errno_) __attribute__((__unused__)) int _saved_errno_ = errno
 
 static inline int negative_errno(void) {
         /* This helper should be used to shut up gcc if you know 'errno' is

--- a/src/core/dbus-execute.c
+++ b/src/core/dbus-execute.c
@@ -17,6 +17,7 @@
   along with systemd; If not, see <http://www.gnu.org/licenses/>.
 ***/
 
+#include <sys/mount.h>
 #include <sys/prctl.h>
 
 #ifdef HAVE_SECCOMP

--- a/src/core/load-fragment.h
+++ b/src/core/load-fragment.h
@@ -112,7 +112,7 @@ int config_parse_fdname(const char *unit, const char *filename, unsigned line, c
 int config_parse_sec_fix_0(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 
 /* gperf prototypes */
-const struct ConfigPerfItem* load_fragment_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* load_fragment_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 extern const char load_fragment_gperf_nulstr[];
 
 typedef enum Disabled {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -135,7 +135,7 @@ static void pager_open_if_enabled(void) {
         pager_open(false);
 }
 
-noreturn static void freeze_or_reboot(void) {
+_noreturn_ static void freeze_or_reboot(void) {
 
         if (arg_crash_reboot) {
                 log_notice("Rebooting in 10s...");
@@ -150,7 +150,7 @@ noreturn static void freeze_or_reboot(void) {
         freeze();
 }
 
-noreturn static void crash(int sig) {
+_noreturn_ static void crash(int sig) {
         struct sigaction sa;
         pid_t pid;
 

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -19,7 +19,6 @@
   along with systemd; If not, see <http://www.gnu.org/licenses/>.
 ***/
 
-#include <libmount.h>
 #include <stdbool.h>
 #include <stdio.h>
 
@@ -31,6 +30,8 @@
 #include "hashmap.h"
 #include "list.h"
 #include "ratelimit.h"
+
+struct libmnt_monitor;
 
 /* Enforce upper limit how many names we allow */
 #define MANAGER_MAX_NAMES 131072 /* 128K */

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -22,6 +22,8 @@
 #include <stdio.h>
 #include <sys/epoll.h>
 
+#include <libmount.h>
+
 #include "sd-messages.h"
 
 #include "alloc-util.h"

--- a/src/journal/journald-server.h
+++ b/src/journal/journald-server.h
@@ -161,7 +161,7 @@ void server_dispatch_message(Server *s, struct iovec *iovec, unsigned n, unsigne
 void server_driver_message(Server *s, sd_id128_t message_id, const char *format, ...) _printf_(3,0) _sentinel_;
 
 /* gperf lookup function */
-const struct ConfigPerfItem* journald_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* journald_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int config_parse_storage(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 

--- a/src/journal/test-compress.c
+++ b/src/journal/test-compress.c
@@ -26,6 +26,7 @@
 #include "fd-util.h"
 #include "fileio.h"
 #include "macro.h"
+#include "path-util.h"
 #include "random-util.h"
 #include "util.h"
 
@@ -155,8 +156,14 @@ static void test_compress_stream(int compression,
         char pattern[] = "/tmp/systemd-test.compressed.XXXXXX",
              pattern2[] = "/tmp/systemd-test.compressed.XXXXXX";
         int r;
-        _cleanup_free_ char *cmd = NULL, *cmd2;
+        _cleanup_free_ char *cmd = NULL, *cmd2 = NULL;
         struct stat st = {};
+
+        r = find_binary(cat, NULL);
+        if (r < 0) {
+                log_error_errno(r, "Skipping %s, could not find %s binary: %m", __func__, cat);
+                return;
+        }
 
         log_debug("/* testing %s compression */",
                   object_compressed_to_string(compression));

--- a/src/journal/test-journal-interleaving.c
+++ b/src/journal/test-journal-interleaving.c
@@ -36,7 +36,7 @@
 
 static bool arg_keep = false;
 
-noreturn static void log_assert_errno(const char *text, int eno, const char *file, int line, const char *func) {
+_noreturn_ static void log_assert_errno(const char *text, int eno, const char *file, int line, const char *func) {
         log_internal(LOG_CRIT, 0, file, line, func,
                      "'%s' failed at %s:%u (%s): %s.",
                      text, file, line, func, strerror(eno));

--- a/src/libsystemd-network/sd-lldp.c
+++ b/src/libsystemd-network/sd-lldp.c
@@ -19,6 +19,7 @@
 ***/
 
 #include <arpa/inet.h>
+#include <linux/sockios.h>
 
 #include "sd-lldp.h"
 

--- a/src/libsystemd/sd-bus/bus-error.h
+++ b/src/libsystemd/sd-bus/bus-error.h
@@ -51,11 +51,12 @@ int bus_error_set_errnofv(sd_bus_error *e, int error, const char *format, va_lis
 #define BUS_ERROR_MAP_ELF_REGISTER                                      \
         __attribute__ ((__section__("BUS_ERROR_MAP")))                  \
         __attribute__ ((__used__))                                      \
-        __attribute__ ((aligned(8)))
+        __attribute__ ((__aligned__(8)))
 
 #define BUS_ERROR_MAP_ELF_USE(errors)                                   \
         extern const sd_bus_error_map errors[];                         \
-        __attribute__ ((used)) static const sd_bus_error_map * const CONCATENATE(errors ## _copy_, __COUNTER__) = errors;
+        __attribute__ ((__used__))                                      \
+        static const sd_bus_error_map * const CONCATENATE(errors ## _copy_, __COUNTER__) = errors;
 
 /* We use something exotic as end marker, to ensure people build the
  * maps using the macsd-ros. */

--- a/src/libudev/libudev.h
+++ b/src/libudev/libudev.h
@@ -21,6 +21,7 @@
 #define _LIBUDEV_H_
 
 #include <stdarg.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 
 #ifdef __cplusplus

--- a/src/libudev/libudev.h
+++ b/src/libudev/libudev.h
@@ -41,9 +41,9 @@ struct udev *udev_new(void);
 void udev_set_log_fn(struct udev *udev,
                             void (*log_fn)(struct udev *udev,
                                            int priority, const char *file, int line, const char *fn,
-                                           const char *format, va_list args)) __attribute__ ((deprecated));
-int udev_get_log_priority(struct udev *udev) __attribute__ ((deprecated));
-void udev_set_log_priority(struct udev *udev, int priority) __attribute__ ((deprecated));
+                                           const char *format, va_list args)) __attribute__((__deprecated__));
+int udev_get_log_priority(struct udev *udev) __attribute__((__deprecated__));
+void udev_set_log_priority(struct udev *udev, int priority) __attribute__((__deprecated__));
 void *udev_get_userdata(struct udev *udev);
 void udev_set_userdata(struct udev *udev, void *userdata);
 
@@ -170,16 +170,16 @@ struct udev_queue *udev_queue_ref(struct udev_queue *udev_queue);
 struct udev_queue *udev_queue_unref(struct udev_queue *udev_queue);
 struct udev *udev_queue_get_udev(struct udev_queue *udev_queue);
 struct udev_queue *udev_queue_new(struct udev *udev);
-unsigned long long int udev_queue_get_kernel_seqnum(struct udev_queue *udev_queue) __attribute__ ((deprecated));
-unsigned long long int udev_queue_get_udev_seqnum(struct udev_queue *udev_queue) __attribute__ ((deprecated));
+unsigned long long int udev_queue_get_kernel_seqnum(struct udev_queue *udev_queue) __attribute__((__deprecated__));
+        unsigned long long int udev_queue_get_udev_seqnum(struct udev_queue *udev_queue) __attribute__((__deprecated__));
 int udev_queue_get_udev_is_active(struct udev_queue *udev_queue);
 int udev_queue_get_queue_is_empty(struct udev_queue *udev_queue);
-int udev_queue_get_seqnum_is_finished(struct udev_queue *udev_queue, unsigned long long int seqnum) __attribute__ ((deprecated));
+int udev_queue_get_seqnum_is_finished(struct udev_queue *udev_queue, unsigned long long int seqnum) __attribute__((__deprecated__));
 int udev_queue_get_seqnum_sequence_is_finished(struct udev_queue *udev_queue,
-                                               unsigned long long int start, unsigned long long int end) __attribute__ ((deprecated));
+                                               unsigned long long int start, unsigned long long int end) __attribute__((__deprecated__));
 int udev_queue_get_fd(struct udev_queue *udev_queue);
 int udev_queue_flush(struct udev_queue *udev_queue);
-struct udev_list_entry *udev_queue_get_queued_list_entry(struct udev_queue *udev_queue) __attribute__ ((deprecated));
+struct udev_list_entry *udev_queue_get_queued_list_entry(struct udev_queue *udev_queue) __attribute__((__deprecated__));
 
 /*
  *  udev_hwdb

--- a/src/login/logind.h
+++ b/src/login/logind.h
@@ -180,7 +180,7 @@ int manager_unit_is_active(Manager *manager, const char *unit);
 int manager_job_is_active(Manager *manager, const char *path);
 
 /* gperf lookup function */
-const struct ConfigPerfItem* logind_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* logind_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int manager_set_lid_switch_ignore(Manager *m, usec_t until);
 

--- a/src/network/networkd-gperf.c
+++ b/src/network/networkd-gperf.c
@@ -1,0 +1,59 @@
+/* ANSI-C code produced by gperf version 3.1 */
+/* Command-line: gperf  */
+/* Computed positions: -k'' */
+
+
+#include <stddef.h>
+#include "conf-parser.h"
+#include "networkd-conf.h"
+#include <string.h>
+
+#define TOTAL_KEYWORDS 2
+#define MIN_WORD_LENGTH 13
+#define MAX_WORD_LENGTH 16
+#define MIN_HASH_VALUE 13
+#define MAX_HASH_VALUE 16
+/* maximum key range = 4, duplicates = 0 */
+
+#ifdef __GNUC__
+__inline
+#else
+#ifdef __cplusplus
+inline
+#endif
+#endif
+/*ARGSUSED*/
+static unsigned int
+networkd_gperf_hash (register const char *str, register size_t len)
+{
+  return len;
+}
+
+const struct ConfigPerfItem *
+networkd_gperf_lookup (register const char *str, register size_t len)
+{
+  static const struct ConfigPerfItem wordlist[] =
+    {
+      {(char*)0}, {(char*)0}, {(char*)0}, {(char*)0},
+      {(char*)0}, {(char*)0}, {(char*)0}, {(char*)0},
+      {(char*)0}, {(char*)0}, {(char*)0}, {(char*)0},
+      {(char*)0},
+      {"DHCP.DUIDType",              config_parse_duid_type,                 0,          offsetof(Manager, duid.type)},
+      {(char*)0}, {(char*)0},
+      {"DHCP.DUIDRawData",           config_parse_duid_rawdata,              0,          offsetof(Manager, duid)}
+    };
+
+  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
+    {
+      register unsigned int key = networkd_gperf_hash (str, len);
+
+      if (key <= MAX_HASH_VALUE)
+        {
+          register const char *s = wordlist[key].section_and_lvalue;
+
+          if (s && *str == *s && !strcmp (str + 1, s + 1))
+            return &wordlist[key];
+        }
+    }
+  return 0;
+}

--- a/src/network/networkd-netdev.h
+++ b/src/network/networkd-netdev.h
@@ -204,7 +204,7 @@ NetDevKind netdev_kind_from_string(const char *d) _pure_;
 int config_parse_netdev_kind(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 
 /* gperf */
-const struct ConfigPerfItem* network_netdev_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* network_netdev_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 /* Macros which append INTERFACE= to the message */
 

--- a/src/network/networkd-network.h
+++ b/src/network/networkd-network.h
@@ -187,7 +187,7 @@ int config_parse_dhcp_use_domains(const char *unit, const char *filename, unsign
 /* Legacy IPv4LL support */
 int config_parse_ipv4ll(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 
-const struct ConfigPerfItem* network_network_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* network_network_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 extern const sd_bus_vtable network_vtable[];
 

--- a/src/nspawn/nspawn-settings.h
+++ b/src/nspawn/nspawn-settings.h
@@ -88,7 +88,7 @@ bool settings_private_network(Settings *s);
 
 DEFINE_TRIVIAL_CLEANUP_FUNC(Settings*, settings_free);
 
-const struct ConfigPerfItem* nspawn_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* nspawn_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int config_parse_capability(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 int config_parse_id128(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);

--- a/src/resolve/dns-type.c
+++ b/src/resolve/dns-type.c
@@ -29,7 +29,7 @@ typedef const struct {
 } dns_type;
 
 static const struct dns_type_name *
-lookup_dns_type (register const char *str, register unsigned int len);
+lookup_dns_type (register const char *str, register GPERF_LEN_TYPE len);
 
 #include "dns_type-from-name.h"
 #include "dns_type-to-name.h"

--- a/src/resolve/resolved-conf.h
+++ b/src/resolve/resolved-conf.h
@@ -29,7 +29,7 @@ int manager_parse_search_domains_and_warn(Manager *m, const char *string);
 int manager_add_dns_server_by_string(Manager *m, DnsServerType type, const char *word);
 int manager_parse_dns_server_string_and_warn(Manager *m, DnsServerType type, const char *string);
 
-const struct ConfigPerfItem* resolved_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* resolved_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int config_parse_dns_servers(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 int config_parse_search_domains(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);

--- a/src/shared/pager.c
+++ b/src/shared/pager.c
@@ -40,7 +40,7 @@
 
 static pid_t pager_pid = 0;
 
-noreturn static void pager_fallback(void) {
+_noreturn_ static void pager_fallback(void) {
         int r;
 
         r = copy_bytes(STDIN_FILENO, STDOUT_FILENO, (uint64_t) -1, false);

--- a/src/systemd/_sd-common.h
+++ b/src/systemd/_sd-common.h
@@ -28,22 +28,22 @@
 
 #ifndef _sd_printf_
 #  if __GNUC__ >= 4
-#    define _sd_printf_(a,b) __attribute__ ((format (printf, a, b)))
+#    define _sd_printf_(a,b) __attribute__ ((__format__(printf, a, b)))
 #  else
 #    define _sd_printf_(a,b)
 #  endif
 #endif
 
 #ifndef _sd_sentinel_
-#  define _sd_sentinel_ __attribute__((sentinel))
+#  define _sd_sentinel_ __attribute__((__sentinel__))
 #endif
 
 #ifndef _sd_packed_
-#  define _sd_packed_ __attribute__((packed))
+#  define _sd_packed_ __attribute__((__packed__))
 #endif
 
 #ifndef _sd_pure_
-#  define _sd_pure_ __attribute__((pure))
+#  define _sd_pure_ __attribute__((__pure__))
 #endif
 
 #ifndef _SD_STRINGIFY

--- a/src/systemd/sd-device.h
+++ b/src/systemd/sd-device.h
@@ -22,6 +22,7 @@
 ***/
 
 #include <inttypes.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 
 #include "_sd-common.h"

--- a/src/test/test-af-list.c
+++ b/src/test/test-af-list.c
@@ -24,7 +24,7 @@
 #include "string-util.h"
 #include "util.h"
 
-static const struct af_name* lookup_af(register const char *str, register unsigned int len);
+static const struct af_name* lookup_af(register const char *str, register GPERF_LEN_TYPE len);
 
 #include "af-from-name.h"
 #include "af-list.h"

--- a/src/test/test-arphrd-list.c
+++ b/src/test/test-arphrd-list.c
@@ -24,7 +24,7 @@
 #include "string-util.h"
 #include "util.h"
 
-static const struct arphrd_name* lookup_arphrd(register const char *str, register unsigned int len);
+static const struct arphrd_name* lookup_arphrd(register const char *str, register GPERF_LEN_TYPE len);
 
 #include "arphrd-from-name.h"
 #include "arphrd-list.h"

--- a/src/timesync/timesyncd-conf.h
+++ b/src/timesync/timesyncd-conf.h
@@ -22,7 +22,7 @@
 #include "conf-parser.h"
 #include "timesyncd-manager.h"
 
-const struct ConfigPerfItem* timesyncd_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* timesyncd_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int manager_parse_server_string(Manager *m, ServerType type, const char *string);
 

--- a/src/udev/collect/collect.c
+++ b/src/udev/collect/collect.c
@@ -56,7 +56,7 @@ static inline struct _mate *node_to_mate(struct udev_list_node *node)
         return container_of(node, struct _mate, node);
 }
 
-noreturn static void sig_alrm(int signo)
+_noreturn_ static void sig_alrm(int signo)
 {
         exit(4);
 }

--- a/src/udev/net/link-config.h
+++ b/src/udev/net/link-config.h
@@ -92,7 +92,7 @@ const char *mac_policy_to_string(MACPolicy p) _const_;
 MACPolicy mac_policy_from_string(const char *p) _pure_;
 
 /* gperf lookup function */
-const struct ConfigPerfItem* link_config_gperf_lookup(const char *key, unsigned length);
+const struct ConfigPerfItem* link_config_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
 int config_parse_mac_policy(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);
 int config_parse_name_policy(const char *unit, const char *filename, unsigned line, const char *section, unsigned section_line, const char *lvalue, int ltype, const char *rvalue, void *data, void *userdata);

--- a/src/udev/udev-builtin-hwdb.c
+++ b/src/udev/udev-builtin-hwdb.c
@@ -26,6 +26,7 @@
 
 #include "alloc-util.h"
 #include "hwdb-util.h"
+#include "parse-util.h"
 #include "string-util.h"
 #include "udev-util.h"
 #include "udev.h"
@@ -62,7 +63,7 @@ int udev_builtin_hwdb_lookup(struct udev_device *dev,
 
 static const char *modalias_usb(struct udev_device *dev, char *s, size_t size) {
         const char *v, *p;
-        int vn, pn;
+        uint16_t vn, pn;
 
         v = udev_device_get_sysattr_value(dev, "idVendor");
         if (!v)
@@ -70,11 +71,9 @@ static const char *modalias_usb(struct udev_device *dev, char *s, size_t size) {
         p = udev_device_get_sysattr_value(dev, "idProduct");
         if (!p)
                 return NULL;
-        vn = strtol(v, NULL, 16);
-        if (vn <= 0)
+        if (safe_atoux16(v, &vn) < 0)
                 return NULL;
-        pn = strtol(p, NULL, 16);
-        if (pn <= 0)
+        if (safe_atoux16(p, &pn) < 0)
                 return NULL;
         snprintf(s, size, "usb:v%04Xp%04X*", vn, pn);
         return s;

--- a/src/udev/udev-builtin-keyboard.c
+++ b/src/udev/udev-builtin-keyboard.c
@@ -29,7 +29,7 @@
 #include "string-util.h"
 #include "udev.h"
 
-static const struct key *keyboard_lookup_key(const char *str, unsigned len);
+static const struct key *keyboard_lookup_key(const char *str, GPERF_LEN_TYPE len);
 #include "keyboard-keys-from-name.h"
 
 static int install_force_release(struct udev_device *dev, const unsigned *release, unsigned release_count) {

--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -236,7 +236,8 @@ static int dev_pci_slot(struct udev_device *dev, struct netnames *names) {
                 err = -ENOENT;
                 goto out;
         }
-        xsprintf(slots, "%s/slots", udev_device_get_syspath(pci));
+        if (!snprintf_ok(slots, sizeof slots, "%s/slots", udev_device_get_syspath(pci)))
+                return -ENAMETOOLONG;
         dir = opendir(slots);
         if (!dir) {
                 err = -errno;
@@ -255,10 +256,10 @@ static int dev_pci_slot(struct udev_device *dev, struct netnames *names) {
                         continue;
                 if (i < 1)
                         continue;
-                xsprintf(str, "%s/%s/address", slots, dent->d_name);
-                if (read_one_line_file(str, &address) >= 0) {
+                if (snprintf_ok(str, sizeof str, "%s/%s/address", slots, dent->d_name) &&
+                    read_one_line_file(str, &address) >= 0) {
                         /* match slot address with device by stripping the function */
-                        if (strneq(address, udev_device_get_sysname(names->pcidev), strlen(address)))
+                        if (streq(address, udev_device_get_sysname(names->pcidev)))
                                 hotplug_slot = i;
                         free(address);
                 }
@@ -398,7 +399,6 @@ static int names_ccw(struct  udev_device *dev, struct netnames *names) {
         struct udev_device *cdev;
         const char *bus_id;
         size_t bus_id_len;
-        int rc;
 
         assert(dev);
         assert(names);
@@ -436,8 +436,7 @@ static int names_ccw(struct  udev_device *dev, struct netnames *names) {
         bus_id += strspn(bus_id, ".0");
 
         /* Store the CCW bus-ID for use as network device name */
-        rc = snprintf(names->ccw_group, sizeof(names->ccw_group), "c%s", bus_id);
-        if (rc >= 0 && rc < (int)sizeof(names->ccw_group))
+        if (snprintf_ok(names->ccw_group, sizeof(names->ccw_group), "c%s", bus_id))
                 names->type = NET_CCWGROUP;
         return 0;
 }
@@ -551,7 +550,7 @@ static int builtin_net_id(struct udev_device *dev, int argc, char *argv[], bool 
         if (err >= 0 && names.type == NET_CCWGROUP) {
                 char str[IFNAMSIZ];
 
-                if (snprintf(str, sizeof(str), "%s%s", prefix, names.ccw_group) < (int)sizeof(str))
+                if (snprintf_ok(str, sizeof str, "%s%s", prefix, names.ccw_group))
                         udev_builtin_add_property(dev, test, "ID_NET_NAME_PATH", str);
                 goto out;
         }
@@ -565,21 +564,21 @@ static int builtin_net_id(struct udev_device *dev, int argc, char *argv[], bool 
         if (names.type == NET_PCI) {
                 char str[IFNAMSIZ];
 
-                if (names.pci_onboard[0])
-                        if (snprintf(str, sizeof(str), "%s%s", prefix, names.pci_onboard) < (int)sizeof(str))
-                                udev_builtin_add_property(dev, test, "ID_NET_NAME_ONBOARD", str);
+                if (names.pci_onboard[0] &&
+                    snprintf_ok(str, sizeof str, "%s%s", prefix, names.pci_onboard))
+                        udev_builtin_add_property(dev, test, "ID_NET_NAME_ONBOARD", str);
 
-                if (names.pci_onboard_label)
-                        if (snprintf(str, sizeof(str), "%s%s", prefix, names.pci_onboard_label) < (int)sizeof(str))
-                                udev_builtin_add_property(dev, test, "ID_NET_LABEL_ONBOARD", str);
+                if (names.pci_onboard_label &&
+                    snprintf_ok(str, sizeof str, "%s%s", prefix, names.pci_onboard_label))
+                        udev_builtin_add_property(dev, test, "ID_NET_LABEL_ONBOARD", str);
 
-                if (names.pci_path[0])
-                        if (snprintf(str, sizeof(str), "%s%s", prefix, names.pci_path) < (int)sizeof(str))
-                                udev_builtin_add_property(dev, test, "ID_NET_NAME_PATH", str);
+                if (names.pci_path[0] &&
+                    snprintf_ok(str, sizeof str, "%s%s", prefix, names.pci_path))
+                        udev_builtin_add_property(dev, test, "ID_NET_NAME_PATH", str);
 
-                if (names.pci_slot[0])
-                        if (snprintf(str, sizeof(str), "%s%s", prefix, names.pci_slot) < (int)sizeof(str))
-                                udev_builtin_add_property(dev, test, "ID_NET_NAME_SLOT", str);
+                if (names.pci_slot[0] &&
+                    snprintf_ok(str, sizeof str, "%s%s", prefix, names.pci_slot))
+                        udev_builtin_add_property(dev, test, "ID_NET_NAME_SLOT", str);
                 goto out;
         }
 
@@ -588,13 +587,13 @@ static int builtin_net_id(struct udev_device *dev, int argc, char *argv[], bool 
         if (err >= 0 && names.type == NET_USB) {
                 char str[IFNAMSIZ];
 
-                if (names.pci_path[0])
-                        if (snprintf(str, sizeof(str), "%s%s%s", prefix, names.pci_path, names.usb_ports) < (int)sizeof(str))
-                                udev_builtin_add_property(dev, test, "ID_NET_NAME_PATH", str);
+                if (names.pci_path[0] &&
+                    snprintf_ok(str, sizeof str, "%s%s%s", prefix, names.pci_path, names.usb_ports))
+                        udev_builtin_add_property(dev, test, "ID_NET_NAME_PATH", str);
 
-                if (names.pci_slot[0])
-                        if (snprintf(str, sizeof(str), "%s%s%s", prefix, names.pci_slot, names.usb_ports) < (int)sizeof(str))
-                                udev_builtin_add_property(dev, test, "ID_NET_NAME_SLOT", str);
+                if (names.pci_slot[0] &&
+                    snprintf_ok(str, sizeof str, "%s%s%s", prefix, names.pci_slot, names.usb_ports))
+                        udev_builtin_add_property(dev, test, "ID_NET_NAME_SLOT", str);
                 goto out;
         }
 
@@ -603,13 +602,13 @@ static int builtin_net_id(struct udev_device *dev, int argc, char *argv[], bool 
         if (err >= 0 && names.type == NET_BCMA) {
                 char str[IFNAMSIZ];
 
-                if (names.pci_path[0])
-                        if (snprintf(str, sizeof(str), "%s%s%s", prefix, names.pci_path, names.bcma_core) < (int)sizeof(str))
-                                udev_builtin_add_property(dev, test, "ID_NET_NAME_PATH", str);
+                if (names.pci_path[0] &&
+                    snprintf_ok(str, sizeof str, "%s%s%s", prefix, names.pci_path, names.bcma_core))
+                        udev_builtin_add_property(dev, test, "ID_NET_NAME_PATH", str);
 
-                if (names.pci_slot[0])
-                        if (snprintf(str, sizeof(str), "%s%s%s", prefix, names.pci_slot, names.bcma_core) < (int)sizeof(str))
-                                udev_builtin_add_property(dev, test, "ID_NET_NAME_SLOT", str);
+                if (names.pci_slot[0] &&
+                    snprintf(str, sizeof str, "%s%s%s", prefix, names.pci_slot, names.bcma_core))
+                        udev_builtin_add_property(dev, test, "ID_NET_NAME_SLOT", str);
                 goto out;
         }
 out:

--- a/src/udev/udev.h
+++ b/src/udev/udev.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <sys/param.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 
 #include "libudev.h"


### PR DESCRIPTION
Same as #20, for v229.

v233 and earlier used automake, so it won't pass Semaphore CI since that expects to use Meson/ninja instead. But locally this builds fine (with recent compilers and headers), so I think we should still merge this.

/cc @keszybz