### PR TITLE
[241] shared/install: Preserve escape characters for escaped unit names

### DIFF
--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -2796,7 +2796,7 @@ static int split_pattern_into_name_and_instances(const char *pattern, char **out
         assert(out_instances);
         assert(out_unit_name);
 
-        r = extract_first_word(&pattern, &unit_name, NULL, 0);
+        r = extract_first_word(&pattern, &unit_name, NULL, EXTRACT_RETAIN_ESCAPE);
         if (r < 0)
                 return r;
 


### PR DESCRIPTION
This backports systemd/systemd#12053 for Fedora 30 / Fedora CoreOS.