### PR TITLE
fstab-generator: use DefaultDependencies=no for /sysroot mounts

### DIFF
--- a/src/fstab-generator/fstab-generator.c
+++ b/src/fstab-generator/fstab-generator.c
@@ -353,6 +353,12 @@ static int add_mount(
                 "Documentation=man:fstab(5) man:systemd-fstab-generator(8)\n",
                 source);
 
+        /* All mounts under /sysroot need to happen later, at initrd-fs.target time. IOW, it's not
+         * technically part of the basic initrd filesystem itself, and so shouldn't inherit the default
+         * Before=local-fs.target dependency. */
+        if (in_initrd() && path_startswith(where, "/sysroot"))
+                fprintf(f, "DefaultDependencies=no\n");
+
         if (STRPTR_IN_SET(fstype, "nfs", "nfs4") && !(flags & AUTOMOUNT) &&
             fstab_test_yes_no_option(opts, "bg\0" "fg\0")) {
                 /* The default retry timeout that mount.nfs uses for 'bg' mounts


### PR DESCRIPTION
Otherwise we can end up with an ordering cycle. Since d54bab90, all
local mounts now gain a default `Before=local-fs.target` dependency.
This doesn't make sense for `/sysroot` mounts in the initrd though,
since those happen later in the boot process.

Closes: #12231

---

Backport of https://github.com/systemd/systemd/pull/12281. We'd like to get this into f30 for Fedora CoreOS.