### PR TITLE
V244 stable, network-generator and makefs fixes

### DIFF
--- a/src/network/generator/network-generator.c
+++ b/src/network/generator/network-generator.c
@@ -574,7 +574,7 @@ static int parse_netmask_or_prefixlen(int family, const char **value, unsigned c
 
 static int parse_cmdline_ip_address(Context *context, int family, const char *value) {
         union in_addr_union addr = {}, peer = {}, gateway = {};
-        const char *hostname, *ifname, *dhcp_type, *dns, *p;
+        const char *hostname = NULL, *ifname, *dhcp_type, *dns, *p;
         unsigned char prefixlen;
         int r;
 
@@ -599,9 +599,11 @@ static int parse_cmdline_ip_address(Context *context, int family, const char *va
         if (!p)
                 return -EINVAL;
 
-        hostname = strndupa(value, p - value);
-        if (!hostname_is_valid(hostname, false))
-                return -EINVAL;
+        if (p != value) {
+                hostname = strndupa(value, p - value);
+                if (!hostname_is_valid(hostname, false))
+                        return -EINVAL;
+        }
 
         value = p + 1;
 

--- a/src/partition/makefs.c
+++ b/src/partition/makefs.c
@@ -43,8 +43,7 @@ static int makefs(const char *type, const char *device) {
 }
 
 static int run(int argc, char *argv[]) {
-        const char *device, *type;
-        _cleanup_free_ char *detected = NULL;
+        _cleanup_free_ char *device = NULL, *type = NULL, *detected = NULL;
         struct stat st;
         int r;
 
@@ -54,8 +53,14 @@ static int run(int argc, char *argv[]) {
                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL),
                                        "This program expects two arguments.");
 
-        type = argv[1];
-        device = argv[2];
+        /* type and device must be copied because makefs calls safe_fork, which clears argv[] */
+        type = strdup(argv[1]);
+        if (!type)
+                return -ENOMEM;
+
+        device = strdup(argv[2]);
+        if (!device)
+                return -ENOMEM;
 
         if (stat(device, &st) < 0)
                 return log_error_errno(errno, "Failed to stat \"%s\": %m", device);


### PR DESCRIPTION
Ran into these bugs which were fixed in systemd v245. Bugs were found on a system built from Buildroot 2020.02.