### PR TITLE
V244 stable: backport CVE-2020-13776 and downstream Buildroot patches

### DIFF
--- a/src/basic/parse-util.h
+++ b/src/basic/parse-util.h
@@ -46,9 +46,13 @@ static inline int safe_atoux16(const char *s, uint16_t *ret) {
 
 int safe_atoi16(const char *s, int16_t *ret);
 
-static inline int safe_atou32(const char *s, uint32_t *ret_u) {
+static inline int safe_atou32_full(const char *s, unsigned base, uint32_t *ret_u) {
         assert_cc(sizeof(uint32_t) == sizeof(unsigned));
-        return safe_atou(s, (unsigned*) ret_u);
+        return safe_atou_full(s, base, (unsigned*) ret_u);
+}
+
+static inline int safe_atou32(const char *s, uint32_t *ret_u) {
+        return safe_atou32_full(s, 0, (unsigned*) ret_u);
 }
 
 static inline int safe_atoi32(const char *s, int32_t *ret_i) {

--- a/src/basic/user-util.c
+++ b/src/basic/user-util.c
@@ -46,7 +46,7 @@ int parse_uid(const char *s, uid_t *ret) {
         assert(s);
 
         assert_cc(sizeof(uid_t) == sizeof(uint32_t));
-        r = safe_atou32(s, &uid);
+        r = safe_atou32_full(s, 10, &uid);
         if (r < 0)
                 return r;
 

--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -351,7 +351,7 @@ static int request_parse_range(
         return 0;
 }
 
-static int request_parse_arguments_iterator(
+static mhd_result request_parse_arguments_iterator(
                 void *cls,
                 enum MHD_ValueKind kind,
                 const char *key,
@@ -798,7 +798,7 @@ static int request_handler_machine(
         return MHD_queue_response(connection, MHD_HTTP_OK, response);
 }
 
-static int request_handler(
+static mhd_result request_handler(
                 void *cls,
                 struct MHD_Connection *connection,
                 const char *url,

--- a/src/journal-remote/journal-remote-main.c
+++ b/src/journal-remote/journal-remote-main.c
@@ -252,7 +252,7 @@ static int process_http_upload(
         return mhd_respond(connection, MHD_HTTP_ACCEPTED, "OK.");
 };
 
-static int request_handler(
+static mhd_result request_handler(
                 void *cls,
                 struct MHD_Connection *connection,
                 const char *url,

--- a/src/journal-remote/microhttpd-util.h
+++ b/src/journal-remote/microhttpd-util.h
@@ -47,6 +47,12 @@
 #  define MHD_create_response_from_fd_at_offset64 MHD_create_response_from_fd_at_offset
 #endif
 
+#if MHD_VERSION >= 0x00097002
+#  define mhd_result enum MHD_Result
+#else
+#  define mhd_result int
+#endif
+
 void microhttpd_logger(void *arg, const char *fmt, va_list ap) _printf_(2, 0);
 
 /* respond_oom() must be usable with return, hence this form. */

--- a/src/random-seed/random-seed.c
+++ b/src/random-seed/random-seed.c
@@ -19,6 +19,7 @@
 #include "io-util.h"
 #include "log.h"
 #include "main-func.h"
+#include "missing_random.h"
 #include "missing_syscall.h"
 #include "mkdir.h"
 #include "parse-util.h"

--- a/src/test/test-user-util.c
+++ b/src/test/test-user-util.c
@@ -46,9 +46,19 @@ static void test_parse_uid(void) {
 
         r = parse_uid("65535", &uid);
         assert_se(r == -ENXIO);
+        assert_se(uid == 100);
+
+        r = parse_uid("0x1234", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid("01234", &uid);
+        assert_se(r == 0);
+        assert_se(uid == 1234);
 
         r = parse_uid("asdsdas", &uid);
         assert_se(r == -EINVAL);
+        assert_se(uid == 1234);
 }
 
 static void test_uid_ptr(void) {


### PR DESCRIPTION
Backport fix from v275 for CVE-2020-13776 per #70

Backport downstream patches from Buildroot 2020.02.x using v244. That fix build issues with uhttpd 0.9.71 and compiling with old Sourcery toolchains.
https://git.busybox.net/buildroot/tree/package/systemd/0001-random-seed-add-missing-header-for-GRND_NONBLOCK.patch?h=2020.02.x
https://git.busybox.net/buildroot/tree/package/systemd/0001-Fix-build-with-libmicrohttpd-0.9.71.patch?h=2020.02.x