### PR TITLE
meson: check that cxx variable is set before using it

### DIFF
--- a/src/systemd/meson.build
+++ b/src/systemd/meson.build
@@ -54,7 +54,7 @@ if cc.has_argument('-std=iso9899:2017')
         opts += [['c', '-std=iso9899:2017']]
 endif
 
-if add_languages('cpp', required : false)
+if cxx_cmd != ''
         opts += [['c++'],
                  ['c++', '-std=c++98'],
                  ['c++', '-std=c++11']]


### PR DESCRIPTION
In some cases it is not defined. Eg in a yocto build:

src/systemd/meson.build:61:15: ERROR: Unknown variable cxx.

(cherry picked from commit 442bc2afee6c5f731c7b3e76ccab7301703a45a7)

From: https://github.com/systemd/systemd/pull/17840