### PR TITLE
Fix nss-resolve to properly fallback in a Flatpak sandbox

### DIFF
--- a/src/nss-resolve/nss-resolve.c
+++ b/src/nss-resolve/nss-resolve.c
@@ -23,7 +23,8 @@ NSS_GETHOSTBYNAME_PROTOTYPES(resolve);
 NSS_GETHOSTBYADDR_PROTOTYPES(resolve);
 
 static bool bus_error_shall_fallback(sd_bus_error *e) {
-        return sd_bus_error_has_name(e, SD_BUS_ERROR_SERVICE_UNKNOWN) ||
+        return sd_bus_error_get_errno(e) == ENOTCONN ||
+               sd_bus_error_has_name(e, SD_BUS_ERROR_SERVICE_UNKNOWN) ||
                sd_bus_error_has_name(e, SD_BUS_ERROR_NAME_HAS_NO_OWNER) ||
                sd_bus_error_has_name(e, SD_BUS_ERROR_NO_REPLY) ||
                sd_bus_error_has_name(e, SD_BUS_ERROR_ACCESS_DENIED) ||


### PR DESCRIPTION
For unknown reasons, sd-bus has trouble connecting to the filtered
D-Bus system proxy exported by Flatpak and the connection to the
bus is closed during authentication. Don't mistake this for a remote
error - that was causing a hard "not found" failure rather than a fallback.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1912131 for background.