### PR TITLE
dissect: fix root hash signature autodiscovery

### DIFF
--- a/src/shared/dissect-image.c
+++ b/src/shared/dissect-image.c
@@ -2123,7 +2123,7 @@ int verity_settings_load(
                 }
         }
 
-        if (verity->root_hash && !verity->root_hash_sig) {
+        if ((root_hash || verity->root_hash) && !verity->root_hash_sig) {
                 if (root_hash_sig_path) {
                         r = read_full_file_full(AT_FDCWD, root_hash_sig_path, 0, NULL, (char**) &root_hash_sig, &root_hash_sig_size);
                         if (r < 0 && r != -ENOENT)


### PR DESCRIPTION
The root hash signature is auto discovered only if the root hash was specified
manually. Ensure that an auto discovered root hash is also enough.

(cherry picked from commit 90f989861e1f7fd4465a8dddd1721b54ecb3f273)

Regression introduced in v247