### PR TITLE
boot: Move console declarations to missing_efi.h

### DIFF
--- a/src/boot/efi/console.c
+++ b/src/boot/efi/console.c
@@ -9,63 +9,6 @@
 #define SYSTEM_FONT_WIDTH 8
 #define SYSTEM_FONT_HEIGHT 19
 
-#define EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID \
-        { 0xdd9e7534, 0x7762, 0x4698, { 0x8c, 0x14, 0xf5, 0x85, 0x17, 0xa6, 0x25, 0xaa } }
-
-struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL;
-
-typedef EFI_STATUS (EFIAPI *EFI_INPUT_RESET_EX)(
-        struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *This,
-        BOOLEAN ExtendedVerification
-);
-
-typedef UINT8 EFI_KEY_TOGGLE_STATE;
-
-typedef struct {
-        UINT32 KeyShiftState;
-        EFI_KEY_TOGGLE_STATE KeyToggleState;
-} EFI_KEY_STATE;
-
-typedef struct {
-        EFI_INPUT_KEY Key;
-        EFI_KEY_STATE KeyState;
-} EFI_KEY_DATA;
-
-typedef EFI_STATUS (EFIAPI *EFI_INPUT_READ_KEY_EX)(
-        struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *This,
-        EFI_KEY_DATA *KeyData
-);
-
-typedef EFI_STATUS (EFIAPI *EFI_SET_STATE)(
-        struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *This,
-        EFI_KEY_TOGGLE_STATE *KeyToggleState
-);
-
-typedef EFI_STATUS (EFIAPI *EFI_KEY_NOTIFY_FUNCTION)(
-        EFI_KEY_DATA *KeyData
-);
-
-typedef EFI_STATUS (EFIAPI *EFI_REGISTER_KEYSTROKE_NOTIFY)(
-        struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *This,
-        EFI_KEY_DATA KeyData,
-        EFI_KEY_NOTIFY_FUNCTION KeyNotificationFunction,
-        VOID **NotifyHandle
-);
-
-typedef EFI_STATUS (EFIAPI *EFI_UNREGISTER_KEYSTROKE_NOTIFY)(
-        struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *This,
-        VOID *NotificationHandle
-);
-
-typedef struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL {
-        EFI_INPUT_RESET_EX Reset;
-        EFI_INPUT_READ_KEY_EX ReadKeyStrokeEx;
-        EFI_EVENT WaitForKeyEx;
-        EFI_SET_STATE SetState;
-        EFI_REGISTER_KEYSTROKE_NOTIFY RegisterKeyNotify;
-        EFI_UNREGISTER_KEYSTROKE_NOTIFY UnregisterKeyNotify;
-} EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL;
-
 EFI_STATUS console_key_read(UINT64 *key, BOOLEAN wait) {
         EFI_GUID EfiSimpleTextInputExProtocolGuid = EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID;
         static EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *TextInputEx;

--- a/src/boot/efi/console.h
+++ b/src/boot/efi/console.h
@@ -1,11 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
-#define EFI_SHIFT_STATE_VALID           0x80000000
-#define EFI_RIGHT_CONTROL_PRESSED       0x00000004
-#define EFI_LEFT_CONTROL_PRESSED        0x00000008
-#define EFI_RIGHT_ALT_PRESSED           0x00000010
-#define EFI_LEFT_ALT_PRESSED            0x00000020
+#include "missing_efi.h"
 
 #define EFI_CONTROL_PRESSED             (EFI_RIGHT_CONTROL_PRESSED|EFI_LEFT_CONTROL_PRESSED)
 #define EFI_ALT_PRESSED                 (EFI_RIGHT_ALT_PRESSED|EFI_LEFT_ALT_PRESSED)

--- a/src/boot/efi/missing_efi.h
+++ b/src/boot/efi/missing_efi.h
@@ -53,3 +53,70 @@ typedef struct _EFI_RNG_PROTOCOL {
 } EFI_RNG_PROTOCOL;
 
 #endif
+
+#ifndef EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID
+
+#define EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID \
+        { 0xdd9e7534, 0x7762, 0x4698, { 0x8c, 0x14, 0xf5, 0x85, 0x17, 0xa6, 0x25, 0xaa } }
+
+#define EFI_SHIFT_STATE_VALID           0x80000000
+#define EFI_RIGHT_CONTROL_PRESSED       0x00000004
+#define EFI_LEFT_CONTROL_PRESSED        0x00000008
+#define EFI_RIGHT_ALT_PRESSED           0x00000010
+#define EFI_LEFT_ALT_PRESSED            0x00000020
+
+struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL;
+
+typedef EFI_STATUS (EFIAPI *EFI_INPUT_RESET_EX)(
+        struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *This,
+        BOOLEAN ExtendedVerification
+);
+
+typedef UINT8 EFI_KEY_TOGGLE_STATE;
+
+typedef struct {
+        UINT32 KeyShiftState;
+        EFI_KEY_TOGGLE_STATE KeyToggleState;
+} EFI_KEY_STATE;
+
+typedef struct {
+        EFI_INPUT_KEY Key;
+        EFI_KEY_STATE KeyState;
+} EFI_KEY_DATA;
+
+typedef EFI_STATUS (EFIAPI *EFI_INPUT_READ_KEY_EX)(
+        struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *This,
+        EFI_KEY_DATA *KeyData
+);
+
+typedef EFI_STATUS (EFIAPI *EFI_SET_STATE)(
+        struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *This,
+        EFI_KEY_TOGGLE_STATE *KeyToggleState
+);
+
+typedef EFI_STATUS (EFIAPI *EFI_KEY_NOTIFY_FUNCTION)(
+        EFI_KEY_DATA *KeyData
+);
+
+typedef EFI_STATUS (EFIAPI *EFI_REGISTER_KEYSTROKE_NOTIFY)(
+        struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *This,
+        EFI_KEY_DATA KeyData,
+        EFI_KEY_NOTIFY_FUNCTION KeyNotificationFunction,
+        VOID **NotifyHandle
+);
+
+typedef EFI_STATUS (EFIAPI *EFI_UNREGISTER_KEYSTROKE_NOTIFY)(
+        struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL *This,
+        VOID *NotificationHandle
+);
+
+typedef struct _EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL {
+        EFI_INPUT_RESET_EX Reset;
+        EFI_INPUT_READ_KEY_EX ReadKeyStrokeEx;
+        EFI_EVENT WaitForKeyEx;
+        EFI_SET_STATE SetState;
+        EFI_REGISTER_KEYSTROKE_NOTIFY RegisterKeyNotify;
+        EFI_UNREGISTER_KEYSTROKE_NOTIFY UnregisterKeyNotify;
+} EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL;
+
+#endif


### PR DESCRIPTION
These were added to eficonex.h in gnu-efi 3.0.13. Let's move them
to missing_efi.h behind an appropriate guard to fix the build with
recent versions of gnu-efi.

(cherry picked from commit 95ba433a5f34baf92921fb58051bc8241f908c0e)

Backported from https://github.com/systemd/systemd/pull/18987