### PR TITLE
selinux: do not crash if policy becomes unavailable after reload

### DIFF
--- a/src/basic/selinux-util.c
+++ b/src/basic/selinux-util.c
@@ -168,6 +168,8 @@ int mac_selinux_fix_container(const char *path, const char *inside_path, LabelFi
 
         /* Check for policy reload so 'label_hnd' is kept up-to-date by callbacks */
         (void) avc_netlink_check_nb();
+        if (!label_hnd)
+                return 0;
 
         if (selabel_lookup_raw(label_hnd, &fcon, inside_path, st.st_mode) < 0) {
                 r = -errno;
@@ -364,6 +366,8 @@ static int selinux_create_file_prepare_abspath(const char *abspath, mode_t mode)
 
         /* Check for policy reload so 'label_hnd' is kept up-to-date by callbacks */
         (void) avc_netlink_check_nb();
+        if (!label_hnd)
+                return 0;
 
         r = selabel_lookup_raw(label_hnd, &filecon, abspath, mode);
         if (r < 0) {
@@ -385,7 +389,6 @@ int mac_selinux_create_file_prepare_at(int dirfd, const char *path, mode_t mode)
 #if HAVE_SELINUX
         _cleanup_free_ char *abspath = NULL;
         int r;
-
 
         assert(path);
 
@@ -508,6 +511,8 @@ int mac_selinux_bind(int fd, const struct sockaddr *addr, socklen_t addrlen) {
 
         /* Check for policy reload so 'label_hnd' is kept up-to-date by callbacks */
         (void) avc_netlink_check_nb();
+        if (!label_hnd)
+                goto skipped;
 
         if (path_is_absolute(path))
                 r = selabel_lookup_raw(label_hnd, &fcon, path, S_IFSOCK);


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1944171

Thread 1 (Thread 0x7fb5f0341b80 (LWP 1974)):
№0  selabel_lookup_common (rec=0x0, translating=0, key=0x55f616ac4750 "/run/user/1000/systemd/units/invocation:systemd-tmpfiles-clean.service", type=40960) at label.c:167

'rec' is the handle that we passed.

№1  0x00007fb5f13ae87f in selabel_lookup_raw (rec=<optimized out>, con=con@entry=0x7fffef307380, key=key@entry=0x55f616ac4750 "/run/user/1000/systemd/units/invocation:systemd-tmpfiles-clean.service", type=type@entry=40960) at label.c:256
        lr = <optimized out>

'rec' is passed through as is to selabel_lookup_common().

№2  0x00007fb5f1561b2d in selinux_create_file_prepare_abspath (abspath=0x55f616ac4750 "/run/user/1000/systemd/units/invocation:systemd-tmpfiles-clean.service", mode=40960) at ../src/basic/selinux-util.c:368
        filecon = 0x0
        r = <optimized out>
        __PRETTY_FUNCTION__ = "selinux_create_file_prepare_abspath"
        __func__ = "selinux_create_file_prepare_abspath"

№3  0x00007fb5f1561ec3 in mac_selinux_create_file_prepare (path=<optimized out>, mode=40960) at ../src/basic/selinux-util.c:431
        r = 0
        abspath = 0x55f616ac4750 "/run/user/1000/systemd/units/invocation:systemd-tmpfiles-clean.service"
        __PRETTY_FUNCTION__ = "mac_selinux_create_file_prepare"

We checked label_hnd != NULL, but then we apparently called
avc_netlink_check_nb(), which reset label_hnd. Yay for global state!

№4  0x00007fb5f1549950 in symlink_atomic_label (from=0x55f6169d8b50 "69a8dcf7a7ac46b29306f2fddbed3edc", to=0x55f616ab8380 "/run/user/1000/systemd/units/invocation:systemd-tmpfiles-clean.service") at ../src/basic/label.c:55
        r = <optimized out>
        __PRETTY_FUNCTION__ = "symlink_atomic_label"

In the logs:

Mar 29 14:48:44 fedorapad.home systemd[1974]: selinux: avc:  received policyload notice (seqno=2)
Mar 29 14:48:44 fedorapad.home systemd[1974]: Failed to initialize SELinux labeling handle: No such file or directory
Mar 29 14:48:44 fedorapad.home systemd[1974]: selinux: avc:  received policyload notice (seqno=3)
Mar 29 14:48:44 fedorapad.home systemd[1974]: selinux: avc:  received setenforce notice (enforcing=0)

--

To be merged after the appropriate patch is merged in `main`.