### PR TITLE
LoadCredentials: do not assert on invalid syntax

### DIFF
--- a/src/core/load-fragment.c
+++ b/src/core/load-fragment.c
@@ -4592,7 +4592,7 @@ int config_parse_load_credential(
         r = extract_first_word(&p, &word, ":", EXTRACT_DONT_COALESCE_SEPARATORS);
         if (r == -ENOMEM)
                 return log_oom();
-        if (r <= 0) {
+        if (r <= 0 || isempty(p)) {
                 log_syntax(unit, LOG_WARNING, filename, line, r, "Invalid syntax, ignoring: %s", rvalue);
                 return 0;
         }


### PR DESCRIPTION
LoadCredentials=foo causes an assertion to be triggered, as we
are not checking that the rvalue's right hand side part is non-empty
before using it in unit_full_printf.

Fixes https://github.com/systemd/systemd/issues/19178

```
# printf [Service]nLoadCredential=passwd.hashed-password.rootn > hello.service
# systemd-analyze verify ./hello.service
...
Assertion 'format' failed at src/core/unit-printf.c:232, function unit_full_printf(). Aborting.
Aborted (core dumped)
```