### PR TITLE
hostnamectl: fix hyperlink in "Operating System" field (v248)

### DIFF
--- a/src/hostname/hostnamectl.c
+++ b/src/hostname/hostnamectl.c
@@ -155,17 +155,10 @@ static int print_status_info(StatusInfo *i) {
         }
 
         if (!isempty(i->os_pretty_name)) {
-                _cleanup_free_ char *formatted = NULL;
-                const char *t = i->os_pretty_name;
-
-                if (i->home_url) {
-                        if (terminal_urlify(i->home_url, i->os_pretty_name, &formatted) >= 0)
-                                t = formatted;
-                }
-
                 r = table_add_many(table,
                                    TABLE_STRING, "Operating System:",
-                                   TABLE_STRING, t);
+                                   TABLE_STRING, i->os_pretty_name,
+                                   TABLE_SET_URL, i->home_url);
                 if (r < 0)
                         return table_log_add_error(r);
         }


### PR DESCRIPTION
This fixes a bug introduced by 822be62fb23ed0ec1062ffd18057e53f6c2f8c01.

Before this, if terminal width is not enough, the all subsequent lines
are included in the hyperlink.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1955475.

(cherry picked from commit 8fc1efa88fb935ab4357fa39ed71ccb70df55d7e)