### PR TITLE
networkd: Do not stall systemd-network-wait-online.

### DIFF
--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -749,15 +749,12 @@ void link_check_ready(Link *link) {
                         if (in_addr_is_null(AF_INET6, (const union in_addr_union*) &link->ipv6ll_address) > 0)
                                 return;
 
-                if ((link_dhcp4_enabled(link) && !link_dhcp6_enabled(link) &&
-                     !link->dhcp4_configured) ||
-                    (link_dhcp6_enabled(link) && !link_dhcp4_enabled(link) &&
-                     !link->dhcp6_configured) ||
-                    (link_dhcp4_enabled(link) && link_dhcp6_enabled(link) &&
-                     !link->dhcp4_configured && !link->dhcp6_configured))
-                        return;
-
-                if (link_ipv6_accept_ra_enabled(link) && !link->ndisc_configured)
+                if ((link_dhcp4_enabled(link) || link_dhcp6_enabled(link) || link_ipv6_accept_ra_enabled(link)) &&
+                    !link->dhcp4_configured &&
+                    !link->dhcp6_configured &&
+                    !link->ndisc_configured)
+                        /* When DHCP or RA is enabled, at least one protocol must
+                         * provide an address. */
                         return;
         }
 


### PR DESCRIPTION
When IPV6 configurations are enabled and there is only IPV4 network,
systemd will wait for NDISC timeout to happen before marking a link in
configured state. Due to this systemd-network-wait-online will wait for
12 seconds (timeout period) and this will delay the boot process.

To avoid this, following changes from systemd can be helpful:
 - https://github.com/systemd/systemd/commit/552081a4992
 - https://github.com/systemd/systemd/commit/3cd5924c850

Signed-off-by: Vaibhav Rustagi <vaibhavrustagi@google.com>