### PR TITLE
[v248] network: use address_equal()/route_equal() to compare addresses or routes configured by NDisc

### DIFF
--- a/src/network/networkd-address.c
+++ b/src/network/networkd-address.c
@@ -128,7 +128,7 @@ Address *address_free(Address *address) {
                 set_remove(address->link->dhcp6_pd_addresses, address);
                 set_remove(address->link->dhcp6_pd_addresses_old, address);
                 SET_FOREACH(n, address->link->ndisc_addresses)
-                        if (n->address == address)
+                        if (address_equal(n->address, address))
                                 free(set_remove(address->link->ndisc_addresses, n));
 
                 if (address->family == AF_INET6 &&

--- a/src/network/networkd-route.c
+++ b/src/network/networkd-route.c
@@ -279,7 +279,7 @@ Route *route_free(Route *route) {
                 set_remove(route->link->dhcp6_pd_routes, route);
                 set_remove(route->link->dhcp6_pd_routes_old, route);
                 SET_FOREACH(n, route->link->ndisc_routes)
-                        if (n->route == route)
+                        if (route_equal(n->route, route))
                                 free(set_remove(route->link->ndisc_routes, n));
         }
 
@@ -435,7 +435,7 @@ DEFINE_HASH_OPS_WITH_KEY_DESTRUCTOR(
                 route_compare_func,
                 route_free);
 
-static bool route_equal(const Route *r1, const Route *r2) {
+bool route_equal(const Route *r1, const Route *r2) {
         if (r1 == r2)
                 return true;
 

--- a/src/network/networkd-route.h
+++ b/src/network/networkd-route.h
@@ -65,6 +65,7 @@ typedef struct Route {
 
 void route_hash_func(const Route *route, struct siphash *state);
 int route_compare_func(const Route *a, const Route *b);
+bool route_equal(const Route *r1, const Route *r2);
 extern const struct hash_ops route_hash_ops;
 
 int route_new(Route **ret);


### PR DESCRIPTION
Fixes https://github.com/systemd/systemd/issues/20244.

(cherry picked from commit 10e417b3eac03c1bcd0b5f3d5c24291ac644e164)