### PR TITLE
[v247]: introduce ManageForeignRoutingPolicyRules= boolean setting in networkd.conf

### DIFF
--- a/man/networkd.conf.xml
+++ b/man/networkd.conf.xml
@@ -63,6 +63,15 @@
       </varlistentry>
 
       <varlistentry>
+        <term><varname>ManageForeignRoutingPolicyRules=</varname></term>
+        <listitem><para>A boolean. When true, <command>systemd-networkd</command> will remove rules
+        that are not configured in .network files (except for rules with protocol
+        <literal>kernel</literal>). When false, it will not remove any foreign rules, keeping them even
+        if they are not configured in a .network file. Defaults to yes.
+        </para></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>ManageForeignRoutes=</varname></term>
         <listitem><para>A boolean. When true, <command>systemd-networkd</command> will store any routes
         configured by other tools in its memory. When false, <command>systemd-networkd</command> will

--- a/man/networkd.conf.xml
+++ b/man/networkd.conf.xml
@@ -73,10 +73,13 @@
 
       <varlistentry>
         <term><varname>ManageForeignRoutes=</varname></term>
-        <listitem><para>A boolean. When true, <command>systemd-networkd</command> will store any routes
-        configured by other tools in its memory. When false, <command>systemd-networkd</command> will
-        not manage the foreign routes, thus they are kept even if <varname>KeepConfiguration=</varname>
-        is false. Defaults to yes.</para></listitem>
+        <listitem><para>A boolean. When true, <command>systemd-networkd</command> will remove routes
+        that are not configured in .network files (except for routes with protocol
+        <literal>kernel</literal>, <literal>dhcp</literal> when <varname>KeepConfiguration=</varname>
+        is true or <literal>dhcp</literal>, and <literal>static</literal> when
+        <varname>KeepConfiguration=</varname> is true or <literal>static</literal>). When false, it will
+        not remove any foreign routes, keeping them even if they are not configured in a .network file.
+        Defaults to yes.</para></listitem>
       </varlistentry>
 
     </variablelist>

--- a/src/network/networkd-gperf.gperf
+++ b/src/network/networkd-gperf.gperf
@@ -18,8 +18,9 @@ struct ConfigPerfItem;
 %struct-type
 %includes
 %%
-Network.SpeedMeter,            config_parse_bool,                      0,          offsetof(Manager, use_speed_meter)
-Network.SpeedMeterIntervalSec, config_parse_sec,                       0,          offsetof(Manager, speed_meter_interval_usec)
-Network.ManageForeignRoutes,   config_parse_bool,                      0,          offsetof(Manager, manage_foreign_routes)
-DHCP.DUIDType,                 config_parse_duid_type,                 0,          offsetof(Manager, duid)
-DHCP.DUIDRawData,              config_parse_duid_rawdata,              0,          offsetof(Manager, duid)
+Network.SpeedMeter,                      config_parse_bool,                      0,          offsetof(Manager, use_speed_meter)
+Network.SpeedMeterIntervalSec,           config_parse_sec,                       0,          offsetof(Manager, speed_meter_interval_usec)
+Network.ManageForeignRoutingPolicyRules, config_parse_bool,                      0,          offsetof(Manager, manage_foreign_rules)
+Network.ManageForeignRoutes,             config_parse_bool,                      0,          offsetof(Manager, manage_foreign_routes)
+DHCP.DUIDType,                           config_parse_duid_type,                 0,          offsetof(Manager, duid)
+DHCP.DUIDRawData,                        config_parse_duid_rawdata,              0,          offsetof(Manager, duid)

--- a/src/network/networkd-manager.c
+++ b/src/network/networkd-manager.c
@@ -797,6 +797,7 @@ int manager_new(Manager **ret) {
         *m = (Manager) {
                 .speed_meter_interval_usec = SPEED_METER_DEFAULT_TIME_INTERVAL,
                 .manage_foreign_routes = true,
+                .manage_foreign_rules = true,
                 .ethtool_fd = -1,
         };
 
@@ -1057,6 +1058,9 @@ static int manager_enumerate_rules(Manager *m) {
 
         assert(m);
         assert(m->rtnl);
+
+        if (!m->manage_foreign_rules)
+                return 0;
 
         r = sd_rtnl_message_new_routing_policy_rule(m->rtnl, &req, RTM_GETRULE, 0);
         if (r < 0)

--- a/src/network/networkd-manager.h
+++ b/src/network/networkd-manager.h
@@ -31,6 +31,7 @@ struct Manager {
         bool dirty:1;
         bool restarting:1;
         bool manage_foreign_routes;
+        bool manage_foreign_rules;
 
         Set *dirty_links;
 

--- a/src/network/networkd-routing-policy-rule.c
+++ b/src/network/networkd-routing-policy-rule.c
@@ -944,6 +944,8 @@ int manager_rtnl_process_rule(sd_netlink *rtnl, sd_netlink_message *message, Man
         case RTM_NEWRULE:
                 if (rule)
                         log_routing_policy_rule_debug(tmp, tmp->family, "Received remembered", NULL);
+                else if (!m->manage_foreign_routes)
+                        log_routing_policy_rule_debug(tmp, tmp->family, "Ignoring received foreign", NULL);
                 else {
                         log_routing_policy_rule_debug(tmp, tmp->family, "Remembering foreign", NULL);
                         r = routing_policy_rule_consume_foreign(m, TAKE_PTR(tmp));

--- a/src/network/networkd.conf
+++ b/src/network/networkd.conf
@@ -15,6 +15,7 @@
 [Network]
 #SpeedMeter=no
 #SpeedMeterIntervalSec=10sec
+#ManageForeignRoutingPolicyRules=yes
 #ManageForeignRoutes=yes
 #RouteTable=
 


### PR DESCRIPTION
This backports https://github.com/systemd/systemd/pull/19287.

This introduces a kind of new feature, but this is an important follow-up for 0b81225e5791f660506f7db0ab88078cf296b771, which is already backported to v247-stable.

See https://github.com/systemd/systemd/pull/19287#issuecomment-910906645.