### PR TITLE
[v248] network: fix wrong flag: manage_foreign_routes -> manage_foreign_rules

### DIFF
--- a/src/network/networkd-routing-policy-rule.c
+++ b/src/network/networkd-routing-policy-rule.c
@@ -977,7 +977,7 @@ int manager_rtnl_process_rule(sd_netlink *rtnl, sd_netlink_message *message, Man
         case RTM_NEWRULE:
                 if (rule)
                         log_routing_policy_rule_debug(tmp, tmp->family, "Received remembered", NULL, m);
-                else if (!m->manage_foreign_routes)
+                else if (!m->manage_foreign_rules)
                         log_routing_policy_rule_debug(tmp, tmp->family, "Ignoring received foreign", NULL, m);
                 else {
                         log_routing_policy_rule_debug(tmp, tmp->family, "Remembering foreign", NULL, m);


### PR DESCRIPTION
Fixes a bug in d94dfe7053d49fa62c4bfc07b7f3fc2227c10aff.

(cherry picked from commit 771a36439e955906290afc16a6fb3b10401892cf)