### PR TITLE
[v249] socket-util: cmsg buffer size fix

### DIFF
--- a/src/journal/journald-server.c
+++ b/src/journal/journald-server.c
@@ -1277,7 +1277,7 @@ int server_process_datagram(
          * identical to NAME_MAX. For now we use that, but this should be updated one day when the final
          * limit is known. */
         CMSG_BUFFER_TYPE(CMSG_SPACE(sizeof(struct ucred)) +
-                         CMSG_SPACE(sizeof(struct timeval)) +
+                         CMSG_SPACE_TIMEVAL +
                          CMSG_SPACE(sizeof(int)) + /* fd */
                          CMSG_SPACE(NAME_MAX) /* selinux label */) control;
 

--- a/src/libsystemd-network/icmp6-util.c
+++ b/src/libsystemd-network/icmp6-util.c
@@ -186,7 +186,6 @@ int icmp6_receive(int fd, void *buffer, size_t size, struct in6_addr *ret_dst,
 
         /* namelen == 0 only happens when running the test-suite over a socketpair */
 
-        assert(!(msg.msg_flags & MSG_CTRUNC));
         assert(!(msg.msg_flags & MSG_TRUNC));
 
         CMSG_FOREACH(cmsg, &msg) {

--- a/src/libsystemd-network/icmp6-util.c
+++ b/src/libsystemd-network/icmp6-util.c
@@ -149,7 +149,7 @@ int icmp6_receive(int fd, void *buffer, size_t size, struct in6_addr *ret_dst,
                   triple_timestamp *ret_timestamp) {
 
         CMSG_BUFFER_TYPE(CMSG_SPACE(sizeof(int)) + /* ttl */
-                         CMSG_SPACE(sizeof(struct timeval))) control;
+                         CMSG_SPACE_TIMEVAL) control;
         struct iovec iov = {};
         union sockaddr_union sa = {};
         struct msghdr msg = {

--- a/src/timesync/timesyncd-manager.c
+++ b/src/timesync/timesyncd-manager.c
@@ -467,6 +467,8 @@ static int manager_receive_response(sd_event_source *source, int fd, uint32_t re
 
                 switch (cmsg->cmsg_type) {
                 case SCM_TIMESTAMPNS:
+                        assert(cmsg->cmsg_len == CMSG_LEN(sizeof(struct timespec)));
+
                         recv_time = (struct timespec *) CMSG_DATA(cmsg);
                         break;
                 }

--- a/src/timesync/timesyncd-manager.c
+++ b/src/timesync/timesyncd-manager.c
@@ -412,7 +412,7 @@ static int manager_receive_response(sd_event_source *source, int fd, uint32_t re
                 .iov_base = &ntpmsg,
                 .iov_len = sizeof(ntpmsg),
         };
-        CMSG_BUFFER_TYPE(CMSG_SPACE(sizeof(struct timespec))) control;
+        CMSG_BUFFER_TYPE(CMSG_SPACE_TIMESPEC) control;
         union sockaddr_union server_addr;
         struct msghdr msghdr = {
                 .msg_iov = &iov,


### PR DESCRIPTION
This backports https://github.com/systemd/systemd/pull/20488 and https://github.com/systemd/systemd/pull/20567.