### PR TITLE
[v248] tpm-util: fix TPM parameter handling

### DIFF
--- a/src/shared/tpm2-util.c
+++ b/src/shared/tpm2-util.c
@@ -228,7 +228,7 @@ static int tpm2_init(const char *device, struct tpm2_context *ret) {
                 if (!tcti)
                         return log_oom();
 
-                rc = info->init(tcti, &sz, device);
+                rc = info->init(tcti, &sz, param);
                 if (rc != TPM2_RC_SUCCESS)
                         return log_error_errno(SYNTHETIC_ERRNO(ENOTRECOVERABLE),
                                                "Failed to initialize TCTI context: %s", sym_Tss2_RC_Decode(rc));


### PR DESCRIPTION
cryptenroll allows to specify a custom TPM driver separated from
parameters with colon e.g. `systemd-cryptenroll --tpm2-device=swtpm:`
tells to load swtpm tss driver and use it as a device.

Unfortunately it does not work, swtpm driver init() fails with

```
debug:tcti:src/tss2-tcti/tcti-swtpm.c:570:Tss2_Tcti_Swtpm_Init() Dup'd conf string to: 0x562f91cbc000
debug:tcti:src/util/key-value-parse.c:85:parse_key_value_string() parsing key/value: swtpm:
WARNING:tcti:src/util/key-value-parse.c:50:parse_key_value() key / value string is invalid
Failed to initialize TCTI context: tcti:A parameter has a bad value
```

It turns out that cryptenroll suppose to use the driver name internally
and strip it before passing the rest of parameters to init() function.
Without doing it swtpm receives incorrect key-value property and gets
confused.

Fix it by passing the correct parameter (without driver name) to the
init() function.

Fixes #20708

(cherry picked from commit 8889564a8da574e4b956e2b6ced34354dee54cd7)