### PR TITLE
explicitly close FIDO2 devices

### DIFF
--- a/src/shared/libfido2-util.c
+++ b/src/shared/libfido2-util.c
@@ -58,6 +58,7 @@ bool (*sym_fido_dev_is_fido2)(const fido_dev_t *) = NULL;
 int (*sym_fido_dev_make_cred)(fido_dev_t *, fido_cred_t *, const char *) = NULL;
 fido_dev_t* (*sym_fido_dev_new)(void) = NULL;
 int (*sym_fido_dev_open)(fido_dev_t *, const char *) = NULL;
+int (*sym_fido_dev_close)(fido_dev_t *) = NULL;
 const char* (*sym_fido_strerr)(int) = NULL;
 
 int dlopen_libfido2(void) {
@@ -106,6 +107,7 @@ int dlopen_libfido2(void) {
                         DLSYM_ARG(fido_dev_make_cred),
                         DLSYM_ARG(fido_dev_new),
                         DLSYM_ARG(fido_dev_open),
+                        DLSYM_ARG(fido_dev_close),
                         DLSYM_ARG(fido_strerr));
 }
 

--- a/src/shared/libfido2-util.h
+++ b/src/shared/libfido2-util.h
@@ -60,6 +60,7 @@ extern bool (*sym_fido_dev_is_fido2)(const fido_dev_t *);
 extern int (*sym_fido_dev_make_cred)(fido_dev_t *, fido_cred_t *, const char *);
 extern fido_dev_t* (*sym_fido_dev_new)(void);
 extern int (*sym_fido_dev_open)(fido_dev_t *, const char *);
+extern int (*sym_fido_dev_close)(fido_dev_t *);
 extern const char* (*sym_fido_strerr)(int);
 
 int dlopen_libfido2(void);
@@ -75,8 +76,10 @@ static inline void fido_assert_free_wrapper(fido_assert_t **p) {
 }
 
 static inline void fido_dev_free_wrapper(fido_dev_t **p) {
-        if (*p)
+        if (*p) {
+                sym_fido_dev_close(*p);
                 sym_fido_dev_free(p);
+        }
 }
 
 static inline void fido_cred_free_wrapper(fido_cred_t **p) {


### PR DESCRIPTION
FIDO2 device access is serialised by libfido2 using flock().
Therefore, make sure to close a FIDO2 device once we are done
with it, or we risk opening it again at a later point and
deadlocking. Fixes #20664.

(cherry picked from commit b6aa89b0a399992c8ea762e6ec4f30cff90618f2)