### PR TITLE
[249] coredump: fix filename in journal when not compressed

### DIFF
--- a/src/coredump/coredump.c
+++ b/src/coredump/coredump.c
@@ -525,6 +525,7 @@ static int save_external_coredump(
         if (lseek(fd, 0, SEEK_SET) == (off_t) -1)
                 return log_error_errno(errno, "Failed to seek on coredump %s: %m", fn);
 
+        *ret_filename = TAKE_PTR(fn);
         *ret_data_fd = TAKE_FD(fd);
         *ret_size = (uint64_t) st.st_size;
         *ret_truncated = truncated;


### PR DESCRIPTION
Since 587f2a5e564cf434c2e0a653f52b8f73e86092d8, filename for
not-compressed coredump is missing from save_external_coredump, making
it write COREDUMP_FILENAME= (empty) in journal, making `coredumpctl`
report it missing but it is actually saved.
This fixes it.

(cherry picked from commit 0cfb0971f0fcd345cae76f6837d9801b6cbde407)