### PR TITLE
[v249] test: use kbd-mode-map we ship in one more test case

### DIFF
--- a/src/locale/test-keymap-util.c
+++ b/src/locale/test-keymap-util.c
@@ -196,11 +196,11 @@ int main(int argc, char **argv) {
 
         test_find_language_fallback();
         test_find_converted_keymap();
-        test_find_legacy_keymap();
 
         assert_se(get_testdata_dir("test-keymap-util/kbd-model-map", &map) >= 0);
         assert_se(setenv("SYSTEMD_KBD_MODEL_MAP", map, 1) == 0);
 
+        test_find_legacy_keymap();
         test_vconsole_convert_to_x11();
         test_x11_convert_to_vconsole();
 


### PR DESCRIPTION
Follow-up for be0cc2ce6c947aafadb3f42dba405269f670b31c.

Fixes https://github.com/systemd/systemd/pull/19670#issuecomment-965817823.

(cherry picked from commit a914901d38e01b90e21883b6a2ca1bec21997201)

Closes #140.