### PR TITLE
[v249] unit_is_bound_by_inactive: fix return pointer check

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -2118,7 +2118,7 @@ bool unit_is_bound_by_inactive(Unit *u, Unit **ret_culprit) {
                         continue;
 
                 if (UNIT_IS_INACTIVE_OR_FAILED(unit_active_state(other))) {
-                        if (*ret_culprit)
+                        if (ret_culprit)
                                 *ret_culprit = other;
 
                         return true;


### PR DESCRIPTION
*ret_culprit should be set if ret_culprit has been passed a non-null value,
checking the previous *ret_culprit value does not make sense.

This would cause the culprit to not properly be assigned, leading to
pid1 crash when a unit could not be stopped.

Fixes: #21476

(cherry picked from commit 3da361064bf550d1818c7cd800a514326058e5f2)