### PR TITLE
meson: fix cross compiling (v249-stable)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -442,7 +442,7 @@ conf.set('SIZEOF_DEV_T', cc.sizeof('dev_t', prefix : '#include <sys/types.h>'))
 conf.set('SIZEOF_INO_T', cc.sizeof('ino_t', prefix : '#include <sys/types.h>'))
 conf.set('SIZEOF_TIME_T', cc.sizeof('time_t', prefix : '#include <sys/time.h>'))
 conf.set('SIZEOF_RLIM_T', cc.sizeof('rlim_t', prefix : '#include <sys/resource.h>'))
-conf.set('SIZEOF_TIMEX_MEMBER', cc.sizeof('((struct timex *)0)->freq', prefix : '#include <sys/timex.h>'))
+conf.set('SIZEOF_TIMEX_MEMBER', cc.sizeof('typeof(((struct timex *)0)->freq)', prefix : '#include <sys/timex.h>'))
 
 decl_headers = '''
 #include <uchar.h>


### PR DESCRIPTION
(cherry picked from commit 3112d756a36993900b70fbff98e69a2a43b970a8)