### PR TITLE
[v250] random-util: unify RANDOM_ALLOW_INSECURE and !RANDOM_BLOCK and simplify

### DIFF
--- a/src/basic/random-util.h
+++ b/src/basic/random-util.h
@@ -6,11 +6,8 @@
 #include <stdint.h>
 
 typedef enum RandomFlags {
-        RANDOM_EXTEND_WITH_PSEUDO = 1 << 0, /* If we can't get enough genuine randomness, but some, fill up the rest with pseudo-randomness */
-        RANDOM_BLOCK              = 1 << 1, /* Rather block than return crap randomness (only if the kernel supports that) */
-        RANDOM_MAY_FAIL           = 1 << 2, /* If we can't get any randomness at all, return early with -ENODATA */
-        RANDOM_ALLOW_RDRAND       = 1 << 3, /* Allow usage of the CPU RNG */
-        RANDOM_ALLOW_INSECURE     = 1 << 4, /* Allow usage of GRND_INSECURE flag to kernel's getrandom() API */
+        RANDOM_BLOCK              = 1 << 0, /* Rather block than return crap randomness (only if the kernel supports that) */
+        RANDOM_ALLOW_RDRAND       = 1 << 1, /* Allow usage of the CPU RNG */
 } RandomFlags;
 
 int genuine_random_bytes(void *p, size_t n, RandomFlags flags); /* returns "genuine" randomness, optionally filled up with pseudo random, if not enough is available */

--- a/src/test/test-random-util.c
+++ b/src/test/test-random-util.c
@@ -24,11 +24,9 @@ static void test_genuine_random_bytes_one(RandomFlags flags) {
 }
 
 TEST(genuine_random_bytes) {
-        test_genuine_random_bytes_one(RANDOM_EXTEND_WITH_PSEUDO);
         test_genuine_random_bytes_one(0);
         test_genuine_random_bytes_one(RANDOM_BLOCK);
         test_genuine_random_bytes_one(RANDOM_ALLOW_RDRAND);
-        test_genuine_random_bytes_one(RANDOM_ALLOW_INSECURE);
 }
 
 TEST(pseudo_random_bytes) {


### PR DESCRIPTION
This actually fixes a bug on non-x86 devices I encountered on my ODROID C-2 (aarch64), which is that without this change, with an up to date kernel, systemd winds up hitting `/dev/urandom` for UUID generation when it _should_ be using `getrandom(GRND_INSECURE)`. The result is a needless splat in kmsg and in future kernels possibly a little performance ding for the unoptimized case.

I don't know much about the systemd stable process, but I'm pretty sure this qualifies, so I tried to just do a vanilla cherry pick and append the identifying trailer to the commit message, which follows below.

@bluca Please let me know if I goofed anything up about the process and I can resubmit.

----------------

```
RANDOM_BLOCK has existed for a long time, but RANDOM_ALLOW_INSECURE was
added more recently, leading to an awkward relationship between the two.
It turns out that only one, RANDOM_BLOCK, is needed.

RANDOM_BLOCK means return cryptographically secure numbers no matter
what. If it's not set, it means try to do that, but if it fails, fall
back to using unseeded randomness.

This part of falling back to unseeded randomness is the intent of
GRND_INSECURE, which is what RANDOM_ALLOW_INSECURE previously aliased.
Rather than having an additional flag for that, it makes more sense to
just use it whenever RANDOM_BLOCK is not set. This saves us the overhead
of having to open up /dev/urandom.

Additionally, when getrandom returns too little data, but not zero data,
we currently fall back to using /dev/urandom if RANDOM_BLOCK is not set.
This doesn't quite make sense, because if getrandom returned seeded data
once, then it will forever after return the same thing as whatever
/dev/urandom does. So in that case, we should just loop again.

Since there's never really a time where /dev/urandom is able to return
some easily but more with difficulty, we can also get rid of
RANDOM_EXTEND_WITH_PSEUDO. Once the RNG is initialized, bytes
should just flow normally.

This also makes RANDOM_MAY_FAIL obsolete, because the only case this ran
was where we'd fall back to /dev/urandom on old kernels and return
GRND_INSECURE bytes on new kernels. So also get rid of that flag.

Finally, since we're always able to use GRND_INSECURE on newer kernels,
and we only fall back to /dev/urandom on older kernels, also only fall
back to using RDRAND on those older kernels. There, the only reason to
have RDRAND is to avoid a kmsg entry about unseeded randomness.

The result of this commit is that we now cascade like this:

  - Use getrandom(0) if RANDOM_BLOCK.
  - Use getrandom(GRND_INSECURE) if !RANDOM_BLOCK.
  - Use /dev/urandom if !RANDOM_BLOCK and no GRND_INSECURE support.
  - Use /dev/urandom if no getrandom() support.
  - Use RDRAND if we would use /dev/urandom for any of the above reasons
    and RANDOM_ALLOW_RDRAND is set.

(cherry picked from commit 31234fbeec1c4a8e500106dff4779ccaa5baef83)
```