### PR TITLE
[v250] core: do not return 'skipped' when Condition*= fail with StartUnitWithFlags()

### DIFF
--- a/man/org.freedesktop.systemd1.xml
+++ b/man/org.freedesktop.systemd1.xml
@@ -1193,10 +1193,7 @@ node /org/freedesktop/systemd1 {
 
       <para><function>StartUnitWithFlags()</function> is similar to <function>StartUnit()</function> but
       allows the caller to pass an extra <varname>flags</varname> parameter, which does not support any
-      flags for now, and is reserved for future extensions. The new method also changes the behaviour
-      of the <varname>JobRemoved</varname> signal and make it return <literal>skipped</literal> in case
-      the unit activation job is skipped because a <varname>Condition*=</varname> is not satisfied.
-      With the <varname>StartUnit</varname> method, <literal>done</literal> would be returned instead.</para>
+      flags for now, and is reserved for future extensions.</para>
 
       <para><function>StopUnit()</function> is similar to <function>StartUnit()</function> but stops the
       specified unit rather than starting it. Note that the <literal>isolate</literal> mode is invalid for this

--- a/src/core/dbus-unit.c
+++ b/src/core/dbus-unit.c
@@ -417,10 +417,6 @@ int bus_unit_method_start_generic(
                         return sd_bus_reply_method_errorf(message, SD_BUS_ERROR_INVALID_ARGS,
                                                           "Invalid 'flags' parameter '%" PRIu64 "'",
                                                           input_flags);
-
-                /* The new method unconditionally uses the new behaviour of returning 'skip' when
-                 * a job is skipped. */
-                job_flags |= BUS_UNIT_QUEUE_RETURN_SKIP_ON_CONDITION_FAIL;
         }
 
         r = bus_verify_manage_units_async_full(

--- a/src/core/dbus-unit.h
+++ b/src/core/dbus-unit.h
@@ -31,7 +31,7 @@ int bus_unit_method_thaw(sd_bus_message *message, void *userdata, sd_bus_error *
 typedef enum BusUnitQueueFlags {
         BUS_UNIT_QUEUE_RELOAD_IF_POSSIBLE            = 1 << 0,
         BUS_UNIT_QUEUE_VERBOSE_REPLY                 = 1 << 1,
-        BUS_UNIT_QUEUE_RETURN_SKIP_ON_CONDITION_FAIL = 1 << 2,
+        BUS_UNIT_QUEUE_RETURN_SKIP_ON_CONDITION_FAIL = 1 << 2, // FIXME: currently not used, will be changed soon
 } BusUnitQueueFlags;
 
 int bus_unit_queue_job_one(


### PR DESCRIPTION
Backward incompatible change to avoid returning 'skipped' if a condition causes
a job activation to be skipped when using StartUnitWithFlags().
Job results are broadcasted, so it is theoretically possible that existing
software could get confused if they see this result.

(cherry picked from commit ee3ae55e7537c716530b293c91f3fb9ae22a8049)