### PR TITLE
[v250] packit: build on and use Fedora 36 spec file, drop bfq patch

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -13,6 +13,7 @@ downstream_package_name: systemd
 # `git describe` returns in systemd's case 'v245-xxx' which breaks RPM version
 # detection (that expects 245-xxxx'). Let's tweak the version string accordingly
 upstream_tag_template: "v{version}"
+srpm_build_deps: []
 
 actions:
   post-upstream-clone:

--- a/.packit.yml
+++ b/.packit.yml
@@ -25,6 +25,8 @@ actions:
     # - Patch(0000-0499): backported patches from upstream
     # - Patch0500-9999: downstream-only patches
     - "sed -ri '/^Patch(0[0-4]?[0-9]{0,2})?\\:.+\\.patch/d' .packit_rpm/systemd.spec"
+    # Also drop the bfq scheduler patch, does not apply on v250-stable
+    - "sed -ri '/^Patch0500\\:.+\\.patch/d' .packit_rpm/systemd.spec"
     # Build the RPM with --werror. Even though --werror doesn't work in all
     # cases (see [0]), we can't use -Dc_args=/-Dcpp_args= here because of the
     # RPM hardening macros, that use $CFLAGS/$CPPFLAGS (see [1]).

--- a/.packit.yml
+++ b/.packit.yml
@@ -17,8 +17,8 @@ srpm_build_deps: []
 
 actions:
   post-upstream-clone:
-    # Use the Fedora Rawhide specfile
-    - "git clone https://src.fedoraproject.org/rpms/systemd .packit_rpm --depth=1"
+    # Use the Fedora 36 specfile
+    - "git clone --branch f36 https://src.fedoraproject.org/rpms/systemd .packit_rpm --depth=1"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
     # Drop backported patches from the specfile, but keep the downstream-only ones
@@ -38,7 +38,7 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-rawhide-aarch64
-    - fedora-rawhide-i386
-    - fedora-rawhide-ppc64le
-    - fedora-rawhide-x86_64
+    - fedora-36-aarch64
+    - fedora-36-i386
+    - fedora-36-ppc64le
+    - fedora-36-x86_64


### PR DESCRIPTION
It's targeted to the v250 branch, while the rawhide one follows
the newest upstream release, and the command line options are not
compatible