### PR TITLE
mkosi: add shadow package to SUSE Tumbleweed

### DIFF
--- a/mkosi.default.d/opensuse/10-mkosi.opensuse
+++ b/mkosi.default.d/opensuse/10-mkosi.opensuse
@@ -39,6 +39,7 @@ BuildPackages=
         python3-Jinja2
         python3-lxml
         qrencode-devel
+        shadow
         system-user-nobody
         systemd-sysvinit
         zlib-devel


### PR DESCRIPTION
[1958/1958] Generating export-dbus-interfaces with a custom command
/root/mkosi.build: line 70: groupadd: command not found

(cherry picked from commit 37b7eef35daad03c9d72222dcbfcc11dfe6dc073)