### PR TITLE
bootctl: Make sure bootctl install returns 0 on success

### DIFF
--- a/src/boot/bootctl.c
+++ b/src/boot/bootctl.c
@@ -1969,13 +1969,16 @@ static int verb_install(int argc, char *argv[], void *userdata) {
 
         (void) sync_everything();
 
-        if (arg_touch_variables)
-                r = install_variables(arg_esp_path,
-                                      part, pstart, psize, uuid,
-                                      "/EFI/systemd/systemd-boot" EFI_MACHINE_TYPE_NAME ".efi",
-                                      install);
+        if (!arg_touch_variables)
+                return 0;
 
-        return r;
+        r = install_variables(arg_esp_path, part, pstart, psize, uuid,
+                              "/EFI/systemd/systemd-boot" EFI_MACHINE_TYPE_NAME ".efi",
+                              install);
+        if (r < 0)
+                return r;
+
+        return 0;
 }
 
 static int verb_remove(int argc, char *argv[], void *userdata) {


### PR DESCRIPTION
This backports the same fix from 6e9165397faa1b546d367bdfc28dd4377a8f1d0a
in systemd upstream that we can't backport directly because that commit
introduces a new feature.