### PR TITLE
[v250] analyze: fix crash with online security check

### DIFF
--- a/src/analyze/analyze-security.c
+++ b/src/analyze/analyze-security.c
@@ -536,19 +536,16 @@ static int assess_system_call_architectures(
                 uint64_t *ret_badness,
                 char **ret_description) {
 
-        uint32_t native = 0;
         char *d;
         uint64_t b;
 
         assert(ret_badness);
         assert(ret_description);
 
-        assert_se(seccomp_arch_from_string("native", &native) >= 0);
-
         if (set_isempty(info->system_call_architectures)) {
                 b = 10;
                 d = strdup("Service may execute system calls with all ABIs");
-        } else if (set_contains(info->system_call_architectures, UINT32_TO_PTR(native + 1)) &&
+        } else if (set_contains(info->system_call_architectures, "native") &&
                    set_size(info->system_call_architectures) == 1) {
                 b = 0;
                 d = strdup("Service may execute system calls only with native ABI");
@@ -2571,11 +2568,20 @@ static int get_security_info(Unit *u, ExecContext *c, CGroupContext *g, Security
                                 return log_oom();
                 }
                 info->_umask = c->umask;
-                if (c->syscall_archs) {
-                        info->system_call_architectures = set_copy(c->syscall_archs);
-                        if (!info->system_call_architectures)
+
+#if HAVE_SECCOMP
+                SET_FOREACH(key, c->syscall_archs) {
+                        const char *name;
+
+                        name = seccomp_arch_to_string(PTR_TO_UINT32(key) - 1);
+                        if (!name)
+                                continue;
+
+                        if (set_put_strdup(&info->system_call_architectures, name) < 0)
                                 return log_oom();
                 }
+#endif
+
                 info->system_call_filter_allow_list = c->syscall_allow_list;
                 if (c->syscall_filter) {
                         info->system_call_filter = hashmap_copy(c->syscall_filter);

--- a/test/units/testsuite-65.sh
+++ b/test/units/testsuite-65.sh
@@ -600,6 +600,8 @@ if systemd-analyze --version | grep -q -F "+ELFUTILS"; then
     systemd-analyze inspect-elf --json=short /lib/systemd/systemd | grep -q -F '"elfType":"executable"'
 fi
 
+systemd-analyze --threshold=90 security systemd-journald.service
+
 systemd-analyze log-level info
 
 echo OK >/testok


### PR DESCRIPTION
1449b0f8a96b27 fixed seccomp arch check for the offline case,
but broke it for the normal case, as when coming from D-Bus the
list of seccomp architectures is already converted to string.

Fixes https://github.com/systemd/systemd/issues/23224

(cherry picked from commit e22f2cfa5e79135d9abf53152a292357fe807dc9)