### PR TITLE
[v249] network: do not enable IPv4 ACD for IPv4 link-local address if ACD is…

### DIFF
--- a/man/systemd.network.xml
+++ b/man/systemd.network.xml
@@ -1105,7 +1105,8 @@ IPv6Token=prefixstable:2002:da8:1::</programlisting></para>
             <ulink url="https://tools.ietf.org/html/rfc5227">RFC 5227</ulink>.
             When <literal>ipv6</literal>, performs IPv6 Duplicate Address Detection. See
             <ulink url="https://tools.ietf.org/html/rfc4862">RFC 4862</ulink>.
-            Defaults to <literal>ipv6</literal>.</para>
+            Defaults to <literal>ipv4</literal> for IPv4 link-local addresses, <literal>ipv6</literal> for IPv6
+            addresses, and <literal>none</literal> otherwise.</para>
           </listitem>
         </varlistentry>
         <varlistentry>

--- a/src/network/networkd-address.c
+++ b/src/network/networkd-address.c
@@ -93,7 +93,6 @@ int address_new(Address **ret) {
                 .cinfo.ifa_prefered = CACHE_INFO_INFINITY_LIFE_TIME,
                 .cinfo.ifa_valid = CACHE_INFO_INFINITY_LIFE_TIME,
                 .set_broadcast = -1,
-                .duplicate_address_detection = ADDRESS_FAMILY_IPV6,
         };
 
         *ret = TAKE_PTR(address);
@@ -131,6 +130,8 @@ static int address_new_static(Network *network, const char *filename, unsigned s
         address->network = network;
         address->section = TAKE_PTR(n);
         address->is_static = true;
+        /* This will be adjusted in address_section_verify(). */
+        address->duplicate_address_detection = _ADDRESS_FAMILY_INVALID;
 
         r = ordered_hashmap_ensure_put(&network->addresses_by_section, &network_config_hash_ops, address->section, address);
         if (r < 0)
@@ -1950,6 +1951,8 @@ static int address_section_verify(Address *address) {
                                          address->section->filename, address->section->line);
         }
 
+        assert(IN_SET(address->family, AF_INET, AF_INET6));
+
         if (address_may_have_broadcast(address))
                 address_set_broadcast(address);
         else if (address->broadcast.s_addr != 0) {
@@ -1982,16 +1985,23 @@ static int address_section_verify(Address *address) {
                 address->scope = RT_SCOPE_HOST;
         }
 
+        if (address->duplicate_address_detection < 0) {
+                if (address->family == AF_INET6)
+                        address->duplicate_address_detection = ADDRESS_FAMILY_IPV6;
+                else if (in4_addr_is_link_local(&address->in_addr.in))
+                        address->duplicate_address_detection = ADDRESS_FAMILY_IPV4;
+                else
+                        address->duplicate_address_detection = ADDRESS_FAMILY_NO;
+        } else if (address->duplicate_address_detection == ADDRESS_FAMILY_IPV6 && address->family == AF_INET)
+                log_warning("%s: DuplicateAddressDetection=ipv6 is specified for IPv4 address, ignoring.",
+                            address->section->filename);
+        else if (address->duplicate_address_detection == ADDRESS_FAMILY_IPV4 && address->family == AF_INET6)
+                log_warning("%s: DuplicateAddressDetection=ipv4 is specified for IPv6 address, ignoring.",
+                            address->section->filename);
+
         if (address->family == AF_INET6 &&
             !FLAGS_SET(address->duplicate_address_detection, ADDRESS_FAMILY_IPV6))
                 address->flags |= IFA_F_NODAD;
-
-        if (address->family == AF_INET && in4_addr_is_link_local(&address->in_addr.in) &&
-            !FLAGS_SET(address->duplicate_address_detection, ADDRESS_FAMILY_IPV4)) {
-                log_debug("%s: An IPv4 link-local address is specified, enabling IPv4 Address Conflict Detection (ACD).",
-                          address->section->filename);
-                address->duplicate_address_detection |= ADDRESS_FAMILY_IPV4;
-        }
 
         return 0;
 }

--- a/src/network/networkd-address.h
+++ b/src/network/networkd-address.h
@@ -43,6 +43,9 @@ typedef struct Address {
         bool ip_masquerade_done:1;
         bool is_static:1; /* currently only used by IPv4ACD */
         bool acd_announced:1;
+
+        /* duplicate_address_detection is only used by static or IPv4 dynamic addresses.
+         * To control DAD for IPv6 dynamic addresses, set IFA_F_NODAD to flags. */
         AddressFamily duplicate_address_detection;
         sd_ipv4acd *acd;
 


### PR DESCRIPTION
… disabled explicitly

The commit 1cf4ed142d6c1e2b9dc6a0bc74b6a83ae30b0f8e makes the IPv4 ACD
enabled unconditionally for IPv4 link-local addresses even if users
explicitly disable ACD.

This makes the IPv4 ACD is enabled by default, but honor user setting.

Fixes #22763.

(cherry picked from commit 2859932bd64d61a89f85fa027762bc16961fcf53)