### PR TITLE
[v250] network: create stacked netdevs after the underlying link is activated

### DIFF
--- a/src/network/netdev/netdev.c
+++ b/src/network/netdev/netdev.c
@@ -628,6 +628,11 @@ static bool netdev_is_ready_to_create(NetDev *netdev, Link *link) {
         if (link->set_link_messages > 0)
                 return false;
 
+        /* If stacked netdevs are created before the underlying interface being activated, then
+         * the activation policy for the netdevs are ignored. See issue #22593. */
+        if (!link->activated)
+                return false;
+
         return true;
 }
 


### PR DESCRIPTION
Otherwise, the activation policy for the netdevs are ignored.

Fixes #22593.

(cherry picked from commit 047b9991a4d0d93d0dfe3d144410c619a8b74699)