### PR TITLE
Do not fail EFI build with newer binutils

### DIFF
--- a/src/boot/efi/meson.build
+++ b/src/boot/efi/meson.build
@@ -260,6 +260,13 @@ efi_ldflags = [
         '-z', 'nocombreloc',
         efi_crt0,
 ]
+
+possible_link_flags = [
+        '-Wl,--no-warn-execstack',
+        '-Wl,--no-warn-rwx-segments',
+]
+efi_ldflags += cc.get_supported_link_arguments(possible_link_flags)
+
 if efi_arch[1] in ['aarch64', 'arm', 'riscv64']
         efi_ldflags += ['-shared']
         # Aarch64, ARM32 and 64bit RISC-V don't have an EFI capable objcopy.


### PR DESCRIPTION
Newer binutils versions currently trigger the following warnings due to
a bug in gnu-efi

on arm64:
/usr/bin/ld.bfd: warning: src/boot/efi/systemd-bootaa64.elf has a LOAD segment with RWX permissions

on amd64:
/usr/bin/ld.bfd: warning: /usr/lib/crt0-efi-x86_64.o: missing .note.GNU-stack section implies executable stack

This results in a build failure due to --fatal-warnings.
Work around this issue by suppressing those warnings until gnu-efi has
been fixed.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1013341

(cherry picked from commit b0e5bf0451a6bc94e6e7b2a1de668b75c63f38c8)