### PR TITLE
systemd: Fix systemd builds with newer versions of libseccomp.

### DIFF
--- a/src/shared/seccomp-util.c
+++ b/src/shared/seccomp-util.c
@@ -3,6 +3,8 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/seccomp.h>
+/* include missing_syscall_def.h earlier to make __SNR_foo mapped to __NR_foo. */
+#include "missing_syscall_def.h"
 #include <seccomp.h>
 #include <stddef.h>
 #include <sys/mman.h>


### PR DESCRIPTION
libseccomp 2.5.0+ is required to run newer versions of runc. However, libseccomp 2.5.0+ broke systemd by changing one of its macros. Systemd fixed the breakage here:
https://github.com/systemd/systemd/issues/21969, but in its backport to 249-stable, it doesn't fix the usage in seccomp-util (31f64a65423414bf1d11fc9035450e9b6256858c). This patch backports the missing include from the above issue.