### PR TITLE
[v251 backport] virt: fix container detection

### DIFF
--- a/src/basic/virt.c
+++ b/src/basic/virt.c
@@ -778,7 +778,7 @@ translate_name:
                 /* Some images hardcode container=oci, but OCI is not a specific container manager.
                  * Try to detect one based on well-known files. */
                 v = detect_container_files();
-                if (v != VIRTUALIZATION_NONE)
+                if (v == VIRTUALIZATION_NONE)
                         v = VIRTUALIZATION_CONTAINER_OTHER;
                 goto finish;
         }


### PR DESCRIPTION
Commit 1b86c7c59ecc ("virt: make virtualization enum a named type") made the conversion from `if (!r)` to `if (v != VIRTUALIZATION_NONE)`.

However, the initial test was meaning "if r is null", IOW "if r IS `VIRTUALIZATION_NONE`).

The test is wrong and this can lead to false detection of the container environment (when calling `systemctl exit`).

For example, https://gitlab.freedesktop.org/whot/libevdev/-/jobs/34207974 is calling `systemctl exit 0`, and systemd terminates with the exit code `130`.

Fixing that typo makes `systemctl exit 0` returns `0`.

Fixes: 1b86c7c59ecc26efdf278f5c1c4430346021cd38.
(cherry picked from commit a91078bc57950c9b0c19fd25fb2e802409695304)

---
Backport of https://github.com/systemd/systemd/pull/25941, we need this for [ci-templates](https://gitlab.freedesktop.org/freedesktop/ci-templates) to work with Fedora 37 in a qemu setup.