### PR TITLE
backport "Add missing integration of OOMPolicy in scope units"

### DIFF
--- a/man/org.freedesktop.systemd1.xml
+++ b/man/org.freedesktop.systemd1.xml
@@ -10139,6 +10139,8 @@ node /org/freedesktop/systemd1/unit/session_2d1_2escope {
       readonly t RuntimeMaxUSec = ...;
       @org.freedesktop.DBus.Property.EmitsChangedSignal("const")
       readonly t RuntimeRandomizedExtraUSec = ...;
+      @org.freedesktop.DBus.Property.EmitsChangedSignal("const")
+      readonly s OOMPolicy = '...';
       @org.freedesktop.DBus.Property.EmitsChangedSignal("false")
       readonly s Slice = '...';
       @org.freedesktop.DBus.Property.EmitsChangedSignal("false")
@@ -10312,6 +10314,8 @@ node /org/freedesktop/systemd1/unit/session_2d1_2escope {
     <!--property RuntimeMaxUSec is not documented!-->
 
     <!--property RuntimeRandomizedExtraUSec is not documented!-->
+
+    <!--property OOMPolicy is not documented!-->
 
     <!--property Slice is not documented!-->
 
@@ -10494,6 +10498,8 @@ node /org/freedesktop/systemd1/unit/session_2d1_2escope {
     <variablelist class="dbus-property" generated="True" extra-ref="RuntimeMaxUSec"/>
 
     <variablelist class="dbus-property" generated="True" extra-ref="RuntimeRandomizedExtraUSec"/>
+
+    <variablelist class="dbus-property" generated="True" extra-ref="OOMPolicy"/>
 
     <variablelist class="dbus-property" generated="True" extra-ref="Slice"/>
 

--- a/man/systemd.scope.xml
+++ b/man/systemd.scope.xml
@@ -105,6 +105,8 @@
     of scope units are the following:</para>
 
     <variablelist class='unit-directives'>
+      <xi:include href="systemd.service.xml" xpointer="oom-policy" />
+
       <varlistentry>
         <term><varname>RuntimeMaxSec=</varname></term>
 

--- a/man/systemd.service.xml
+++ b/man/systemd.service.xml
@@ -1120,7 +1120,7 @@
         above.</para></listitem>
       </varlistentry>
 
-      <varlistentry>
+      <varlistentry id='oom-policy'>
         <term><varname>OOMPolicy=</varname></term>
 
         <listitem><para>Configure the out-of-memory (OOM) kernel killer policy. Note that the userspace OOM
@@ -1133,17 +1133,16 @@
         for itself, it might decide to kill a running process in order to free up memory and reduce memory
         pressure. This setting takes one of <constant>continue</constant>, <constant>stop</constant> or
         <constant>kill</constant>. If set to <constant>continue</constant> and a process of the service is
-        killed by the kernel's OOM killer this is logged but the service continues running. If set to
-        <constant>stop</constant> the event is logged but the service is terminated cleanly by the service
-        manager. If set to <constant>kill</constant> and one of the service's processes is killed by the OOM
-        killer the kernel is instructed to kill all remaining processes of the service too, by setting the
+        killed by the OOM killer, this is logged but the unit continues running. If set to
+        <constant>stop</constant> the event is logged but the unit is terminated cleanly by the service
+        manager. If set to <constant>kill</constant> and one of the unit's processes is killed by the OOM
+        killer the kernel is instructed to kill all remaining processes of the unit too, by setting the
         <filename>memory.oom.group</filename> attribute to <constant>1</constant>; also see <ulink
-        url="https://docs.kernel.org/admin-guide/cgroup-v2.html">kernel documentation</ulink>.
-        </para>
+        url="https://docs.kernel.org/admin-guide/cgroup-v2.html">kernel documentation</ulink>.</para>
 
         <para>Defaults to the setting <varname>DefaultOOMPolicy=</varname> in
         <citerefentry><refentrytitle>systemd-system.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>
-        is set to, except for services where <varname>Delegate=</varname> is turned on, where it defaults to
+        is set to, except for units where <varname>Delegate=</varname> is turned on, where it defaults to
         <constant>continue</constant>.</para>
 
         <para>Use the <varname>OOMScoreAdjust=</varname> setting to configure whether processes of the unit
@@ -1153,10 +1152,9 @@
         details.</para>
 
         <para>This setting also applies to <command>systemd-oomd</command>. Similarly to the kernel OOM
-        kills, this setting determines the state of the service after <command>systemd-oomd</command> kills a
-        cgroup associated with the service.</para></listitem>
+        kills, this setting determines the state of the unit after <command>systemd-oomd</command> kills a
+        cgroup associated with it.</para></listitem>
       </varlistentry>
-
     </variablelist>
 
     <para id='shared-unit-options'>Check

--- a/src/core/load-fragment-gperf.gperf.in
+++ b/src/core/load-fragment-gperf.gperf.in
@@ -555,6 +555,7 @@ Path.TriggerLimitBurst,                  config_parse_unsigned,                 
 Scope.RuntimeMaxSec,                     config_parse_sec,                            0,                                  offsetof(Scope, runtime_max_usec)
 Scope.RuntimeRandomizedExtraSec,         config_parse_sec,                            0,                                  offsetof(Scope, runtime_rand_extra_usec)
 Scope.TimeoutStopSec,                    config_parse_sec,                            0,                                  offsetof(Scope, timeout_stop_usec)
+Scope.OOMPolicy,                         config_parse_oom_policy,                     0,                                  offsetof(Scope, oom_policy)
 {# The [Install] section is ignored here #}
 Install.Alias,                           NULL,                                        0,                                  0
 Install.WantedBy,                        NULL,                                        0,                                  0

--- a/src/core/scope.c
+++ b/src/core/scope.c
@@ -43,6 +43,7 @@ static void scope_init(Unit *u) {
         s->timeout_stop_usec = u->manager->default_timeout_stop_usec;
         u->ignore_on_isolate = true;
         s->user = s->group = NULL;
+        s->oom_policy = _OOM_POLICY_INVALID;
 }
 
 static void scope_done(Unit *u) {
@@ -194,6 +195,11 @@ static int scope_add_extras(Scope *s) {
         if (r < 0)
                 return r;
 
+        if (s->oom_policy < 0)
+                s->oom_policy = s->cgroup_context.delegate ? OOM_CONTINUE : UNIT(s)->manager->default_oom_policy;
+
+        s->cgroup_context.memory_oom_group = s->oom_policy == OOM_KILL;
+
         return scope_add_default_dependencies(s);
 }
 
@@ -286,11 +292,13 @@ static void scope_dump(Unit *u, FILE *f, const char *prefix) {
                 "%sScope State: %s\n"
                 "%sResult: %s\n"
                 "%sRuntimeMaxSec: %s\n"
-                "%sRuntimeRandomizedExtraSec: %s\n",
+                "%sRuntimeRandomizedExtraSec: %s\n"
+                "%sOOMPolicy: %s\n",
                 prefix, scope_state_to_string(s->state),
                 prefix, scope_result_to_string(s->result),
                 prefix, FORMAT_TIMESPAN(s->runtime_max_usec, USEC_PER_SEC),
-                prefix, FORMAT_TIMESPAN(s->runtime_rand_extra_usec, USEC_PER_SEC));
+                prefix, FORMAT_TIMESPAN(s->runtime_rand_extra_usec, USEC_PER_SEC),
+                prefix, oom_policy_to_string(s->oom_policy));
 
         cgroup_context_dump(UNIT(s), f, prefix);
         kill_context_dump(&s->kill_context, f, prefix);
@@ -635,11 +643,16 @@ static void scope_notify_cgroup_oom_event(Unit *u, bool managed_oom) {
         else
                 log_unit_debug(u, "Process of control group was killed by the OOM killer.");
 
-        /* This will probably need to be modified when scope units get an oom-policy */
+        if (s->oom_policy == OOM_CONTINUE)
+                return;
+
         switch (s->state) {
 
         case SCOPE_START_CHOWN:
         case SCOPE_RUNNING:
+                scope_enter_signal(s, SCOPE_STOP_SIGTERM, SCOPE_FAILURE_OOM_KILL);
+                break;
+
         case SCOPE_STOP_SIGTERM:
                 scope_enter_signal(s, SCOPE_STOP_SIGKILL, SCOPE_FAILURE_OOM_KILL);
                 break;

--- a/src/core/scope.h
+++ b/src/core/scope.h
@@ -38,6 +38,8 @@ struct Scope {
 
         char *user;
         char *group;
+
+        OOMPolicy oom_policy;
 };
 
 extern const UnitVTable scope_vtable;

--- a/src/login/logind-dbus.c
+++ b/src/login/logind-dbus.c
@@ -3970,6 +3970,12 @@ int manager_start_scope(
         if (r < 0)
                 return r;
 
+        /* For login session scopes, if a process is OOM killed by the kernel, *don't* terminate the rest of
+           the scope */
+        r = sd_bus_message_append(m, "(sv)", "OOMPolicy", "s", "continue");
+        if (r < 0)
+                return r;
+
         /* disable TasksMax= for the session scope, rely on the slice setting for it */
         r = sd_bus_message_append(m, "(sv)", "TasksMax", "t", UINT64_MAX);
         if (r < 0)

--- a/src/shared/bus-unit-util.c
+++ b/src/shared/bus-unit-util.c
@@ -2142,6 +2142,9 @@ static int bus_append_scope_property(sd_bus_message *m, const char *field, const
         if (STR_IN_SET(field, "User", "Group"))
                 return bus_append_string(m, field, eq);
 
+        if (streq(field, "OOMPolicy"))
+                return bus_append_string(m, field, eq);
+
         return 0;
 }
 


### PR DESCRIPTION
This backports https://github.com/systemd/systemd/pull/25385 and https://github.com/systemd/systemd/pull/25725 to v252-stable.

The two PRs fix a regression observed starting from systemd 252, in the [case of using desktop managers that don't partition applications into sub-cgroups](https://github.com/NixOS/nixpkgs/pull/210687#issuecomment-1382904760), and OOM situations killing the whole user session.

Fixes #245.