### PR TITLE
virt: Further improve detection of EC2 metal instances

### DIFF
--- a/src/basic/virt.c
+++ b/src/basic/virt.c
@@ -264,6 +264,7 @@ static Virtualization detect_vm_dmi(void) {
                          * so we fallback to using the product name which is less restricted
                          * to distinguish metal systems from virtualized instances */
                         _cleanup_free_ char *s = NULL;
+                        const char *e;
 
                         r = read_full_virtual_file("/sys/class/dmi/id/product_name", &s, NULL);
                         /* In EC2, virtualized is much more common than metal, so if for some reason
@@ -273,8 +274,9 @@ static Virtualization detect_vm_dmi(void) {
                                                 " assuming virtualized: %m");
                                 return VIRTUALIZATION_AMAZON;
                         }
-                        if (endswith(truncate_nl(s), ".metal")) {
-                                log_debug("DMI product name ends with '.metal', assuming no virtualization");
+                        e = strstr(truncate_nl(s), ".metal");
+                        if (e && IN_SET(e[STRLEN(".metal")], 0, '-')) {
+                                log_debug("DMI product name has '.metal', assuming no virtualization");
                                 return VIRTUALIZATION_NONE;
                         } else
                                 return VIRTUALIZATION_AMAZON;


### PR DESCRIPTION
Commit f90eea7d18d9ebe88e6a66cd7a86b618def8945d
virt: Improve detection of EC2 metal instances

Added support for detecting EC2 metal instances via the product name in DMI by testing for the ".metal" suffix.

Unfortunately this doesn't cover all cases, as there are going to be instance types where ".metal" is not a suffix (ie, .metal-16xl, .metal-32xl, ...)

This modifies the logic to also allow those new forms.

[Modified from upstream to not rely on strstrafter]

Signed-off-by: Benjamin Herrenschmidt <benh@amazon.com>
(cherry picked from commit aab896e2135362ab126830c73284d4af0baad88a)