### PR TITLE
core: fix cgroupv1 realization for delegated units

### DIFF
--- a/src/core/cgroup.c
+++ b/src/core/cgroup.c
@@ -1427,6 +1427,7 @@ static void cgroup_context_apply(
 
         assert(u);
 
+        apply_mask &= unit_get_delegate_mask(u);
         /* Nothing to do? Exit early! */
         if (apply_mask == 0)
                 return;

--- a/src/core/unit-serialize.c
+++ b/src/core/unit-serialize.c
@@ -549,7 +549,7 @@ int unit_deserialize(Unit *u, FILE *f, FDSet *fds) {
          * applied after we are done. For that we invalidate anything already realized, so that we can
          * realize it again. */
         if (u->cgroup_realized) {
-                unit_invalidate_cgroup(u, _CGROUP_MASK_ALL);
+                unit_invalidate_cgroup(u, _CGROUP_MASK_ALL^unit_get_delegate_mask(u));
                 unit_invalidate_cgroup_bpf(u);
         }
 


### PR DESCRIPTION
According to the documentation, systemd should not touch the cgroup settings of units that have Delegate=yes. However, for cgroup v1, systemd would still realize the cgroup settings for those units when ‘systemctl daemon-reload’ was executed. This was inconsistent with the documentation and could cause unexpected behavior.

This commit fixes this issue by setting the cgroup mask bit according to the delegation setting before systemd realizes the cgroup setting of each unit, thus consistent with the documentation.

Here is a demo of the inconsistent behaviour:

```
cat << ! > /usr/lib/systemd/system/yes.service

[Unit]
Description=YES
After=network.target

[Service]
ExecStart=/bin/bash -c 'yes>/dev/null'
Restart=always
Delegate=yes

[Install]
WantedBy=multi-user.target
!
systemctl start yes

echo 5000 > /sys/fs/cgroup/cpu/system.slice/yes.service/cpu.cfs_quota_us
cat /sys/fs/cgroup/cpu/system.slice/yes.service/cpu.cfs_quota_us
Output: 5000
systemctl daemon-reload
cat /sys/fs/cgroup/cpu/system.slice/yes.service/cpu.cfs_quota_us
Output: -1 (should be 5000)
```