### PR TITLE
Backport f26c794308975a875a98faf22a6650d7134f17c1 (find-esp: fix XBOOTLDR stx_dev_major=0 and not btrfs fix)

### DIFF
--- a/src/shared/find-esp.c
+++ b/src/shared/find-esp.c
@@ -814,7 +814,7 @@ int find_xbootldr_and_warn(
         r = verify_xbootldr(p, /* searching= */ true, unprivileged_mode, ret_uuid, ret_devid);
         if (r >= 0)
                 goto found;
-        if (!IN_SET(r, -ENOENT, -EADDRNOTAVAIL, -ENOTDIR)) /* This one is not it */
+        if (!IN_SET(r, -ENOENT, -EADDRNOTAVAIL, -ENOTDIR, -ENOTTY)) /* This one is not it */
                 return r;
 
         return -ENOKEY;


### PR DESCRIPTION
The first part of the fix was backported in cd3d4ab738c8816236d3d52c30c974ad9662017a, but the second wasn't: this is it now.