### PR TITLE
pam: fix cache id

### DIFF
--- a/src/shared/pam-util.c
+++ b/src/shared/pam-util.c
@@ -62,7 +62,7 @@ int pam_acquire_bus_connection(pam_handle_t *handle, const char *module_name, sd
                 return PAM_SERVICE_ERR;
         }
 
-        r = pam_set_data(handle, "systemd-system-bus", bus, cleanup_system_bus);
+        r = pam_set_data(handle, cache_id, bus, cleanup_system_bus);
         if (r != PAM_SUCCESS) {
                 pam_syslog(handle, LOG_ERR, "Failed to set PAM bus data: %s", pam_strerror(handle, r));
                 return r;


### PR DESCRIPTION
Something went wrong in the cherry-picking for
3fc9c413a9bd44b77c7ee8b5dc7decb05e9f2d43. Bus is not stored correctly in the cache. Because authentication calls `pam_acquire_bus_connection` twice, and the first created bus is used after the second one is created, `pam_set_data` disconnects the first one. This results in the following error:

```
Failed to acquire home for user test-user: Transport endpoint is not connected
```