### PR TITLE
Revert "tree-wide: Mount file descriptors via /proc/<pid>/fd"

### DIFF
--- a/src/basic/fd-util.h
+++ b/src/basic/fd-util.h
@@ -7,8 +7,6 @@
 #include <sys/socket.h>
 
 #include "macro.h"
-#include "format-util.h"
-#include "process-util.h"
 #include "stdio-util.h"
 
 /* maximum length of fdname */
@@ -113,17 +111,14 @@ int fd_reopen(int fd, int flags);
 int read_nr_open(void);
 int fd_get_diskseq(int fd, uint64_t *ret);
 
-/* The maximum length a buffer for a /proc/<pid>/fd/<fd> path needs. We intentionally don't use /proc/self/fd
- * as these paths might be read by other programs (for example when mounting file descriptors the source path
- * ends up in /proc/mounts and related files) for which /proc/self/fd will be interpreted differently than
- * /proc/<pid>/fd. */
+/* The maximum length a buffer for a /proc/self/fd/<fd> path needs */
 #define PROC_FD_PATH_MAX \
-        (STRLEN("/proc//fd/") + DECIMAL_STR_MAX(pid_t) + DECIMAL_STR_MAX(int))
+        (STRLEN("/proc/self/fd/") + DECIMAL_STR_MAX(int))
 
 static inline char *format_proc_fd_path(char buf[static PROC_FD_PATH_MAX], int fd) {
         assert(buf);
         assert(fd >= 0);
-        assert_se(snprintf_ok(buf, PROC_FD_PATH_MAX, "/proc/" PID_FMT "/fd/%i", getpid_cached(), fd));
+        assert_se(snprintf_ok(buf, PROC_FD_PATH_MAX, "/proc/self/fd/%i", fd));
         return buf;
 }
 

--- a/src/libsystemd-network/sd-dhcp6-client.c
+++ b/src/libsystemd-network/sd-dhcp6-client.c
@@ -5,9 +5,8 @@
 
 #include <errno.h>
 #include <sys/ioctl.h>
-#include <net/if.h>
-#include <linux/if_arp.h> /* Must be included after <net/if.h> */
-#include <linux/if_infiniband.h> /* Must be included after <net/if.h> */
+#include <linux/if_arp.h>
+#include <linux/if_infiniband.h>
 
 #include "sd-dhcp6-client.h"
 

--- a/src/network/networkd-dhcp-server.c
+++ b/src/network/networkd-dhcp-server.c
@@ -1,9 +1,8 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <netinet/in.h>
-#include <net/if.h>
-#include <linux/if_arp.h> /* Must be included after <net/if.h> */
-#include <linux/if.h> /* Must be included after <net/if.h> */
+#include <linux/if_arp.h>
+#include <linux/if.h>
 
 #include "sd-dhcp-server.h"
 

--- a/src/network/networkd-manager.c
+++ b/src/network/networkd-manager.c
@@ -3,8 +3,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
-#include <net/if.h>
-#include <linux/if.h> /* Must be included after <net/if.h> */
+#include <linux/if.h>
 #include <linux/fib_rules.h>
 #include <linux/nexthop.h>
 #include <linux/nl80211.h>

--- a/src/network/networkd-state-file.c
+++ b/src/network/networkd-state-file.c
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 #include <netinet/in.h>
-#include <net/if.h>
-#include <linux/if.h> /* Must be included after <net/if.h> */
+#include <linux/if.h>
 
 #include "alloc-util.h"
 #include "dns-domain.h"

--- a/src/resolve/resolved-link.c
+++ b/src/resolve/resolved-link.c
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include <net/if.h>
-#include <linux/if.h> /* Must be included after <net/if.h> */
+#include <linux/if.h>
 #include <unistd.h>
 
 #include "sd-network.h"

--- a/src/test/test-fd-util.c
+++ b/src/test/test-fd-util.c
@@ -386,16 +386,11 @@ TEST(close_all_fds) {
 }
 
 TEST(format_proc_fd_path) {
-        _cleanup_free_ char *expected = NULL;
-
-        for (int i = 0; i < 4; i++) {
-                assert_se(asprintf(&expected, "/proc/" PID_FMT "/fd/%i", getpid_cached(), i) >= 0);
-                assert_se(streq_ptr(FORMAT_PROC_FD_PATH(i), expected));
-                expected = mfree(expected);
-        }
-
-        assert_se(asprintf(&expected, "/proc/" PID_FMT "/fd/2147483647", getpid_cached()) >= 0);
-        assert_se(streq_ptr(FORMAT_PROC_FD_PATH(2147483647), expected));
+        assert_se(streq_ptr(FORMAT_PROC_FD_PATH(0), "/proc/self/fd/0"));
+        assert_se(streq_ptr(FORMAT_PROC_FD_PATH(1), "/proc/self/fd/1"));
+        assert_se(streq_ptr(FORMAT_PROC_FD_PATH(2), "/proc/self/fd/2"));
+        assert_se(streq_ptr(FORMAT_PROC_FD_PATH(3), "/proc/self/fd/3"));
+        assert_se(streq_ptr(FORMAT_PROC_FD_PATH(2147483647), "/proc/self/fd/2147483647"));
 }
 
 TEST(fd_reopen) {

--- a/src/udev/net/link-config.c
+++ b/src/udev/net/link-config.c
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-#include <net/if.h>
-#include <linux/netdevice.h> /* Must be included after <net/if.h> */
+#include <linux/netdevice.h>
 #include <netinet/ether.h>
 #include <unistd.h>
 


### PR DESCRIPTION
(cherry picked from commit 7b9da3861a2d27dd31c360674947005a19f3cbe7) (cherry picked from commit d5c180b96ef389da9923985e96504901f52ac605)