### PR TITLE
boot: skip loading DTBs in type 1 when secure boot is enabled

### DIFF
--- a/src/boot/efi/boot.c
+++ b/src/boot/efi/boot.c
@@ -2373,7 +2373,9 @@ static EFI_STATUS image_start(
         if (err != EFI_SUCCESS)
                 return log_error_status(err, "Error loading %ls: %m", entry->loader);
 
-        if (entry->devicetree) {
+        /* DTBs are loaded by the kernel before ExitBootServices, and they can be used to map and assign
+         * arbitrary memory ranges, so skip it when secure boot is enabled as the DTB here is unverified. */
+        if (entry->devicetree && !secure_boot_enabled()) {
                 err = devicetree_install(&dtstate, image_root, entry->devicetree);
                 if (err != EFI_SUCCESS)
                         return log_error_status(err, "Error loading %ls: %m", entry->devicetree);


### PR DESCRIPTION
The kernel loads the DTB from EFI before ExitBootServices():

https://github.com/torvalds/linux/blob/v6.5/drivers/firmware/efi/libstub/fdt.c#L245

DTBs can map and assign arbitrary memory ranges. The kernel refuses to load one from the dtb= kernel command line parameter when secure boot is enabled, as it's not safe. Let's do the same for type 1 entries, as they are unverified.

This only affects arm64 and riscv64, firmwares do not support DTB on x86.

(cherry picked from commit 4b4d612d860a4acbbc22bc64a32637c0eb792cee)