### PR TITLE
network: fix json format for SIP servers (for v253)

### DIFF
--- a/src/network/networkd-json.c
+++ b/src/network/networkd-json.c
@@ -860,8 +860,7 @@ static int sip_build_json(Link *link, JsonVariant **ret) {
                                                elements + n);
                 if (r < 0)
                         goto finalize;
-                if (r > 0)
-                        n++;
+                n++;
         }
 
         r = json_build(ret, JSON_BUILD_OBJECT(JSON_BUILD_PAIR("SIP", JSON_BUILD_VARIANT_ARRAY(elements, n))));


### PR DESCRIPTION
Fixes a bug introduced by 0843ec6c44c7b41b14f6f32d3ee7039e5e615296.

Fixes https://github.com/systemd/systemd/issues/29145.

(In upstream, the issue is fixed by 8d3c5b39b9bbc89953d1da3e9fbff1524c952ac6).