### PR TITLE
machine-id-setup: Generate stable machine IDs on Xen virtual machines.

### DIFF
--- a/man/machine-id.xml
+++ b/man/machine-id.xml
@@ -101,7 +101,8 @@
     to use the D-Bus machine ID from <filename>/var/lib/dbus/machine-id</filename>, the
     value of the kernel command line option <varname>container_uuid</varname>, the KVM DMI
     <filename>product_uuid</filename> or the devicetree <filename>vm,uuid</filename>
-    (on KVM systems), and finally a randomly generated UUID.</para>
+    (on KVM systems), the Xen hypervisor <filename>uuid</filename>, and finally a randomly
+    generated UUID.</para>
 
     <para>After the machine ID is established,
     <citerefentry><refentrytitle>systemd</refentrytitle><manvolnum>1</manvolnum></citerefentry>

--- a/src/libsystemd/sd-id128/id128-util.c
+++ b/src/libsystemd/sd-id128/id128-util.c
@@ -234,6 +234,8 @@ int id128_get_product(sd_id128_t *ret) {
         r = id128_read("/sys/class/dmi/id/product_uuid", ID128_FORMAT_UUID, &uuid);
         if (r == -ENOENT)
                 r = id128_read("/proc/device-tree/vm,uuid", ID128_FORMAT_UUID, &uuid);
+        if (r == -ENOENT)
+                r = id128_read("/sys/hypervisor/uuid", ID128_FORMAT_UUID, &uuid);
         if (r < 0)
                 return r;
 

--- a/src/shared/machine-id-setup.c
+++ b/src/shared/machine-id-setup.c
@@ -78,7 +78,7 @@ static int generate_machine_id(const char *root, sd_id128_t *ret) {
                                 return 0;
                         }
 
-                } else if (IN_SET(detect_vm(), VIRTUALIZATION_KVM, VIRTUALIZATION_AMAZON, VIRTUALIZATION_QEMU)) {
+                } else if (IN_SET(detect_vm(), VIRTUALIZATION_KVM, VIRTUALIZATION_AMAZON, VIRTUALIZATION_QEMU, VIRTUALIZATION_XEN)) {
 
                         /* If we are not running in a container, see if we are running in a VM that provides
                          * a system UUID via the SMBIOS/DMI interfaces.  Such environments include QEMU/KVM


### PR DESCRIPTION
Backport of https://github.com/systemd/systemd/pull/31067

As this only affects new Xen VMs this should be a safe change to introduce to stable.