### PR TITLE
confext and sysext: enable services on OS boot

### DIFF
--- a/presets/90-systemd.preset
+++ b/presets/90-systemd.preset
@@ -17,11 +17,13 @@ enable machines.target
 
 enable getty@.service
 enable systemd-timesyncd.service
+enable systemd-confext.service
 enable systemd-networkd.service
 enable systemd-networkd-wait-online.service
 enable systemd-network-generator.service
 enable systemd-resolved.service
 enable systemd-homed.service
+enable systemd-sysext.service
 enable systemd-userdbd.socket
 enable systemd-pstore.service
 enable systemd-boot-update.service


### PR DESCRIPTION
Adding this to presets instead of making it statically installed. Enable systemd-confext and systemd-sysext service files so that extensions can be picked up automatically on OS boot