### PR TITLE
Backport fchmodat2 changes to 254 to support glibc 2.39

### DIFF
--- a/src/basic/missing_syscall_def.h
+++ b/src/basic/missing_syscall_def.h
@@ -246,6 +246,74 @@ assert_cc(__NR_copy_file_range == systemd_NR_copy_file_range);
 #  endif
 #endif
 
+#ifndef __IGNORE_fchmodat2
+#  if defined(__aarch64__)
+#    define systemd_NR_fchmodat2 452
+#  elif defined(__alpha__)
+#    define systemd_NR_fchmodat2 562
+#  elif defined(__arc__) || defined(__tilegx__)
+#    define systemd_NR_fchmodat2 452
+#  elif defined(__arm__)
+#    define systemd_NR_fchmodat2 452
+#  elif defined(__i386__)
+#    define systemd_NR_fchmodat2 452
+#  elif defined(__ia64__)
+#    define systemd_NR_fchmodat2 1476
+#  elif defined(__loongarch_lp64)
+#    define systemd_NR_fchmodat2 452
+#  elif defined(__m68k__)
+#    define systemd_NR_fchmodat2 452
+#  elif defined(_MIPS_SIM)
+#    if _MIPS_SIM == _MIPS_SIM_ABI32
+#      define systemd_NR_fchmodat2 4452
+#    elif _MIPS_SIM == _MIPS_SIM_NABI32
+#      define systemd_NR_fchmodat2 6452
+#    elif _MIPS_SIM == _MIPS_SIM_ABI64
+#      define systemd_NR_fchmodat2 5452
+#    else
+#      error "Unknown MIPS ABI"
+#    endif
+#  elif defined(__hppa__)
+#    define systemd_NR_fchmodat2 452
+#  elif defined(__powerpc__)
+#    define systemd_NR_fchmodat2 452
+#  elif defined(__riscv)
+#    if __riscv_xlen == 32
+#      define systemd_NR_fchmodat2 452
+#    elif __riscv_xlen == 64
+#      define systemd_NR_fchmodat2 452
+#    else
+#      error "Unknown RISC-V ABI"
+#    endif
+#  elif defined(__s390__)
+#    define systemd_NR_fchmodat2 452
+#  elif defined(__sparc__)
+#    define systemd_NR_fchmodat2 452
+#  elif defined(__x86_64__)
+#    if defined(__ILP32__)
+#      define systemd_NR_fchmodat2 (452 | /* __X32_SYSCALL_BIT */ 0x40000000)
+#    else
+#      define systemd_NR_fchmodat2 452
+#    endif
+#  elif !defined(missing_arch_template)
+#    warning "fchmodat2() syscall number is unknown for your architecture"
+#  endif
+
+/* may be an (invalid) negative number due to libseccomp, see PR 13319 */
+#  if defined __NR_fchmodat2 && __NR_fchmodat2 >= 0
+#    if defined systemd_NR_fchmodat2
+assert_cc(__NR_fchmodat2 == systemd_NR_fchmodat2);
+#    endif
+#  else
+#    if defined __NR_fchmodat2
+#      undef __NR_fchmodat2
+#    endif
+#    if defined systemd_NR_fchmodat2 && systemd_NR_fchmodat2 >= 0
+#      define __NR_fchmodat2 systemd_NR_fchmodat2
+#    endif
+#  endif
+#endif
+
 #ifndef __IGNORE_getrandom
 #  if defined(__aarch64__)
 #    define systemd_NR_getrandom 278

--- a/src/basic/missing_syscalls.py
+++ b/src/basic/missing_syscalls.py
@@ -9,6 +9,7 @@ SYSCALLS = [
     'bpf',
     'close_range',
     'copy_file_range',
+    'fchmodat2',
     'getrandom',
     'memfd_create',
     'mount_setattr',

--- a/src/shared/seccomp-util.c
+++ b/src/shared/seccomp-util.c
@@ -468,6 +468,7 @@ const SyscallFilterSet syscall_filter_sets[_SYSCALL_FILTER_SET_MAX] = {
                 "fchdir\0"
                 "fchmod\0"
                 "fchmodat\0"
+                "fchmodat2\0"
                 "fcntl\0"
                 "fcntl64\0"
                 "fgetxattr\0"

--- a/src/shared/seccomp-util.c
+++ b/src/shared/seccomp-util.c
@@ -2038,7 +2038,7 @@ int seccomp_protect_hostname(void) {
 static int seccomp_restrict_sxid(scmp_filter_ctx seccomp, mode_t m) {
         /* Checks the mode_t parameter of the following system calls:
          *
-         *       → chmod() + fchmod() + fchmodat()
+         *       → chmod() + fchmod() + fchmodat() + fchmodat2()
          *       → open() + creat() + openat()
          *       → mkdir() + mkdirat()
          *       → mknod() + mknodat()
@@ -2078,6 +2078,28 @@ static int seccomp_restrict_sxid(scmp_filter_ctx seccomp, mode_t m) {
                         SCMP_A2(SCMP_CMP_MASKED_EQ, m, m));
         if (r < 0)
                 log_debug_errno(r, "Failed to add filter for fchmodat: %m");
+        else
+                any = true;
+
+#if defined(__SNR_fchmodat2)
+        r = seccomp_rule_add_exact(
+                        seccomp,
+                        SCMP_ACT_ERRNO(EPERM),
+                        SCMP_SYS(fchmodat2),
+                        1,
+                        SCMP_A2(SCMP_CMP_MASKED_EQ, m, m));
+#else
+        /* It looks like this libseccomp does not know about fchmodat2().
+         * Pretend the fchmodat2() system call is not supported at all,
+         * regardless of the kernel version. */
+        r = seccomp_rule_add_exact(
+                        seccomp,
+                        SCMP_ACT_ERRNO(ENOSYS),
+                        __NR_fchmodat2,
+                        0);
+#endif
+        if (r < 0)
+                log_debug_errno(r, "Failed to add filter for fchmodat2: %m");
         else
                 any = true;
 

--- a/src/test/test-seccomp.c
+++ b/src/test/test-seccomp.c
@@ -21,6 +21,7 @@
 #include "macro.h"
 #include "memory-util.h"
 #include "missing_sched.h"
+#include "missing_syscall_def.h"
 #include "nsflags.h"
 #include "nulstr-util.h"
 #include "process-util.h"
@@ -1003,6 +1004,23 @@ static int real_open(const char *path, int flags, mode_t mode) {
 #endif
 }
 
+static int try_fchmodat2(int dirfd, const char *path, int flags, mode_t mode) {
+        /* glibc does not provide a direct wrapper for fchmodat2(). Let's hence define our own wrapper for
+         * testing purposes that calls the real syscall, on architectures and in environments where
+         * SYS_fchmodat2 is defined. Otherwise, let's just fall back to the glibc fchmodat() call. */
+
+#if defined __NR_fchmodat2 && __NR_fchmodat2 >= 0
+        int r;
+        r = (int) syscall(__NR_fchmodat2, dirfd, path, flags, mode);
+        /* The syscall might still be unsupported by kernel or libseccomp. */
+        if (r < 0 && errno == ENOSYS)
+                return fchmodat(dirfd, path, flags, mode);
+        return r;
+#else
+        return fchmodat(dirfd, path, flags, mode);
+#endif
+}
+
 TEST(restrict_suid_sgid) {
         pid_t pid;
 
@@ -1043,6 +1061,11 @@ TEST(restrict_suid_sgid) {
                 assert_se(fchmodat(AT_FDCWD, path, 0755 | S_ISGID, 0) >= 0);
                 assert_se(fchmodat(AT_FDCWD, path, 0755 | S_ISGID | S_ISUID, 0) >= 0);
                 assert_se(fchmodat(AT_FDCWD, path, 0755, 0) >= 0);
+
+                assert_se(try_fchmodat2(AT_FDCWD, path, 0755 | S_ISUID, 0) >= 0);
+                assert_se(try_fchmodat2(AT_FDCWD, path, 0755 | S_ISGID, 0) >= 0);
+                assert_se(try_fchmodat2(AT_FDCWD, path, 0755 | S_ISGID | S_ISUID, 0) >= 0);
+                assert_se(try_fchmodat2(AT_FDCWD, path, 0755, 0) >= 0);
 
                 k = real_open(z, O_CREAT|O_RDWR|O_CLOEXEC|O_EXCL, 0644 | S_ISUID);
                 k = safe_close(k);
@@ -1144,6 +1167,11 @@ TEST(restrict_suid_sgid) {
                 assert_se(fchmodat(AT_FDCWD, path, 0755 | S_ISGID, 0) < 0 && errno == EPERM);
                 assert_se(fchmodat(AT_FDCWD, path, 0755 | S_ISGID | S_ISUID, 0) < 0 && errno == EPERM);
                 assert_se(fchmodat(AT_FDCWD, path, 0755, 0) >= 0);
+
+                assert_se(try_fchmodat2(AT_FDCWD, path, 0755 | S_ISUID, 0) < 0 && errno == EPERM);
+                assert_se(try_fchmodat2(AT_FDCWD, path, 0755 | S_ISGID, 0) < 0 && errno == EPERM);
+                assert_se(try_fchmodat2(AT_FDCWD, path, 0755 | S_ISGID | S_ISUID, 0) < 0 && errno == EPERM);
+                assert_se(try_fchmodat2(AT_FDCWD, path, 0755, 0) >= 0);
 
                 assert_se(real_open(z, O_CREAT|O_RDWR|O_CLOEXEC|O_EXCL, 0644 | S_ISUID) < 0 && errno == EPERM);
                 assert_se(real_open(z, O_CREAT|O_RDWR|O_CLOEXEC|O_EXCL, 0644 | S_ISGID) < 0 && errno == EPERM);


### PR DESCRIPTION
254 is the last systemd release to support split-usr, so we will have probably have some users camping on it for a bit.

These patches should help with supporting glibc 2.39 which uses fchmodat2 internally.