### PR TITLE
docs: don't suffix page permalink with a slash

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@ title: systemd
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://systemd.io" # the base hostname & protocol for your site
 
-permalink: /:title/
+permalink: /:title
 
 # Build settings
 markdown: kramdown

--- a/src/basic/filesystems-gperf.gperf
+++ b/src/basic/filesystems-gperf.gperf
@@ -91,6 +91,7 @@ ocfs2,           {OCFS2_SUPER_MAGIC}
 openpromfs,      {OPENPROM_SUPER_MAGIC}
 orangefs,        {ORANGEFS_DEVREQ_MAGIC}
 overlay,         {OVERLAYFS_SUPER_MAGIC}
+pidfs,           {PID_FS_MAGIC}
 pipefs,          {PIPEFS_MAGIC}
 ppc-cmm,         {PPC_CMM_MAGIC}
 proc,            {PROC_SUPER_MAGIC}

--- a/src/basic/missing_magic.h
+++ b/src/basic/missing_magic.h
@@ -128,6 +128,11 @@
 #define DEVMEM_MAGIC 0x454d444d
 #endif
 
+/* cb12fd8e0dabb9a1c8aef55a6a41e2c255fcdf4b (6.8) */
+#ifndef PID_FS_MAGIC
+#define PID_FS_MAGIC 0x50494446
+#endif
+
 /* Not in mainline but included in Ubuntu */
 #ifndef SHIFTFS_MAGIC
 #define SHIFTFS_MAGIC 0x6a656a62

--- a/src/libsystemd-network/dhcp-option.c
+++ b/src/libsystemd-network/dhcp-option.c
@@ -10,6 +10,8 @@
 #include "alloc-util.h"
 #include "dhcp-option.h"
 #include "dhcp-server-internal.h"
+#include "dns-domain.h"
+#include "hostname-util.h"
 #include "memory-util.h"
 #include "ordered-set.h"
 #include "strv.h"
@@ -417,6 +419,35 @@ int dhcp_option_parse_string(const uint8_t *option, size_t len, char **ret) {
                 return -EINVAL;
 
         *ret = TAKE_PTR(string);
+        return 0;
+}
+
+int dhcp_option_parse_hostname(const uint8_t *option, size_t len, char **ret) {
+        _cleanup_free_ char *hostname = NULL;
+        int r;
+
+        assert(option);
+        assert(ret);
+
+        r = dhcp_option_parse_string(option, len, &hostname);
+        if (r < 0)
+                return r;
+
+        if (!hostname) {
+                *ret = NULL;
+                return 0;
+        }
+
+        if (!hostname_is_valid(hostname, 0))
+                return -EINVAL;
+
+        r = dns_name_is_valid(hostname);
+        if (r < 0)
+                return r;
+        if (r == 0)
+                return -EINVAL;
+
+        *ret = TAKE_PTR(hostname);
         return 0;
 }
 

--- a/src/libsystemd-network/dhcp-option.h
+++ b/src/libsystemd-network/dhcp-option.h
@@ -44,3 +44,4 @@ int dhcp_option_parse(
                 char **ret_error_message);
 
 int dhcp_option_parse_string(const uint8_t *option, size_t len, char **ret);
+int dhcp_option_parse_hostname(const uint8_t *option, size_t len, char **ret);

--- a/src/libsystemd-network/sd-dhcp-server.c
+++ b/src/libsystemd-network/sd-dhcp-server.c
@@ -808,14 +808,16 @@ static int parse_request(uint8_t code, uint8_t len, const void *option, void *us
                 req->agent_info_option = (uint8_t*)option - 2;
 
                 break;
-        case SD_DHCP_OPTION_HOST_NAME:
-                r = dhcp_option_parse_string(option, len, &req->hostname);
-                if (r < 0) {
-                        log_debug_errno(r, "Failed to parse hostname, ignoring: %m");
-                        return 0;
-                }
+        case SD_DHCP_OPTION_HOST_NAME: {
+                _cleanup_free_ char *p = NULL;
 
+                r = dhcp_option_parse_hostname(option, len, &p);
+                if (r < 0)
+                        log_debug_errno(r, "Failed to parse hostname, ignoring: %m");
+                else
+                        free_and_replace(req->hostname, p);
                 break;
+        }
         case SD_DHCP_OPTION_PARAMETER_REQUEST_LIST:
                 req->parameter_request_list = option;
                 req->parameter_request_list_len = len;

--- a/test/TEST-69-SHUTDOWN/test.sh
+++ b/test/TEST-69-SHUTDOWN/test.sh
@@ -38,6 +38,7 @@ EOF
 
     inst /usr/bin/screen
     echo "PS1='screen\$WINDOW # '" >>"$workspace/root/.bashrc"
+    echo "TERM=linux" >>"$workspace/root/.bash_profile"
     echo 'startup_message off' >"$workspace/etc/screenrc"
     echo 'bell_msg ""' >>"$workspace/etc/screenrc"
 }

--- a/test/test-functions
+++ b/test/test-functions
@@ -876,6 +876,7 @@ EOF
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+SyslogIdentifier=sysext-foo
 ExecStart=echo foo
 
 [Install]

--- a/test/test-shutdown.py
+++ b/test/test-shutdown.py
@@ -12,7 +12,6 @@ import pexpect
 
 
 def run(args):
-
     ret = 1
     logger = logging.getLogger("test-shutdown")
     logfile = None
@@ -25,7 +24,7 @@ def run(args):
 
     logger.info("spawning test")
     console = pexpect.spawn(args.command, args.arg, logfile=logfile, env={
-            "TERM": "linux",
+            "TERM": "dumb",
         }, encoding='utf-8', timeout=60)
 
     logger.debug("child pid %d", console.pid)

--- a/test/test-shutdown.py
+++ b/test/test-shutdown.py
@@ -43,6 +43,10 @@ def run(args):
         console.send('c')
         console.expect('screen1 ', 10)
 
+        logger.info('wait for the machine to fully boot')
+        console.sendline('systemctl is-system-running --wait')
+        console.expect(r'\b(running|degraded)\b', 60)
+
 #        console.interact()
 
         console.sendline('tty')

--- a/test/test-shutdown.py
+++ b/test/test-shutdown.py
@@ -15,9 +15,16 @@ def run(args):
 
     ret = 1
     logger = logging.getLogger("test-shutdown")
+    logfile = None
+
+    if args.logfile:
+        logger.debug("Logging pexpect IOs to %s", args.logfile)
+        logfile = open(args.logfile, 'w')
+    elif args.verbose:
+        logfile = sys.stdout
 
     logger.info("spawning test")
-    console = pexpect.spawn(args.command, args.arg, env={
+    console = pexpect.spawn(args.command, args.arg, logfile=logfile, env={
             "TERM": "linux",
         }, encoding='utf-8', timeout=60)
 
@@ -26,12 +33,6 @@ def run(args):
     try:
         logger.info("waiting for login prompt")
         console.expect('H login: ', 10)
-
-        if args.logfile:
-            logger.debug("Logging pexpect IOs to %s", args.logfile)
-            console.logfile = open(args.logfile, 'w')
-        elif args.verbose:
-            console.logfile = sys.stdout
 
         logger.info("log in and start screen")
         console.sendline('root')

--- a/test/test-shutdown.py
+++ b/test/test-shutdown.py
@@ -21,14 +21,17 @@ def run(args):
             "TERM": "linux",
         }, encoding='utf-8', timeout=60)
 
-    if args.verbose:
-        console.logfile = sys.stdout
-
     logger.debug("child pid %d", console.pid)
 
     try:
         logger.info("waiting for login prompt")
         console.expect('H login: ', 10)
+
+        if args.logfile:
+            logger.debug("Logging pexpect IOs to %s", args.logfile)
+            console.logfile = open(args.logfile, 'w')
+        elif args.verbose:
+            console.logfile = sys.stdout
 
         logger.info("log in and start screen")
         console.sendline('root')
@@ -44,7 +47,7 @@ def run(args):
         console.sendline('tty')
         console.expect(r'/dev/(pts/\d+)')
         pty = console.match.group(1)
-        logger.info("window 1 at line %s", pty)
+        logger.info("window 1 at tty %s", pty)
 
         logger.info("schedule reboot")
         console.sendline('shutdown -r')
@@ -112,6 +115,7 @@ def run(args):
 def main():
     parser = argparse.ArgumentParser(description='test logind shutdown feature')
     parser.add_argument("-v", "--verbose", action="store_true", help="verbose")
+    parser.add_argument("--logfile", metavar='FILE', help="Save all test input/output to the given path")
     parser.add_argument("command", help="command to run")
     parser.add_argument("arg", nargs='*', help="args for command")
 

--- a/test/units/testsuite-04.journal.sh
+++ b/test/units/testsuite-04.journal.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# shellcheck disable=SC2317
 set -eux
 set -o pipefail
-
-# This fails due to https://github.com/systemd/systemd/issues/30886
-# but it is too complex and risky to backport, so disable the test
-exit 0
 
 # Rotation/flush test, see https://github.com/systemd/systemd/issues/19895
 journalctl --relinquish-var
@@ -245,6 +242,9 @@ diff -u /tmp/lb1 - <<'EOF'
 [{"index":-3,"boot_id":"5ea5fc4f82a14186b5332a788ef9435e","first_entry":1666569600994371,"last_entry":1666584266223608},{"index":-2,"boot_id":"bea6864f21ad4c9594c04a99d89948b0","first_entry":1666569601005945,"last_entry":1666584347230411},{"index":-1,"boot_id":"4c708e1fd0744336be16f3931aa861fb","first_entry":1666569601017222,"last_entry":1666584354649355},{"index":0,"boot_id":"35e8501129134edd9df5267c49f744a4","first_entry":1666569601009823,"last_entry":1666584438086856}]
 EOF
 rm -rf "$JOURNAL_DIR" /tmp/lb1
+
+# v255-only: skip the following test case, as it suffers from systemd/systemd#30886
+exit 0
 
 # Check that using --after-cursor/--cursor-file= together with journal filters doesn't
 # skip over entries matched by the filter

--- a/test/units/testsuite-50.sh
+++ b/test/units/testsuite-50.sh
@@ -635,7 +635,7 @@ fi
 systemd-sysext unmerge --no-reload
 systemd-sysext merge
 for RETRY in $(seq 60) LAST; do
-  if journalctl --boot --unit foo.service | grep -q -P 'echo\[[0-9]+\]: foo'; then
+  if [[ "$(journalctl --boot _SYSTEMD_UNIT="foo.service" + SYSLOG_IDENTIFIER="sysext-foo" -p info -o cat)" == "foo" ]]; then
     break
   fi
   if [ "${RETRY}" = LAST ]; then

--- a/test/units/testsuite-72.sh
+++ b/test/units/testsuite-72.sh
@@ -22,7 +22,7 @@ fi
 # change the sector size of a file, and we want to test both 512 and 4096 byte
 # sectors. If loopback devices are not supported, we can only test one sector
 # size, and the underlying device is likely to have a sector size of 512 bytes.
-if ! losetup --find >/dev/null 2>&1; then
+if [[ ! -e /dev/loop-control ]]; then
     echo "No loopback device support"
     SECTOR_SIZES="512"
 fi
@@ -108,7 +108,7 @@ for sector_size in $SECTOR_SIZES ; do
     rm -f "$BACKING_FILE"
     truncate -s "$disk_size" "$BACKING_FILE"
 
-    if losetup --find >/dev/null 2>&1; then
+    if [[ -e /dev/loop-control ]]; then
         # shellcheck disable=SC2086
         blockdev="$(losetup --find --show --sector-size $sector_size $BACKING_FILE)"
     else


### PR DESCRIPTION
As it breaks relative links to other pages. For example, the BOOT_LOADER_INTERFACE page has a relative link to
AUTOMATIC_BOOT_ASSESSMENT. With a slash in the page's permalink, that link leads to:

http://127.0.0.1:4000/BOOT_LOADER_INTERFACE/AUTOMATIC_BOOT_ASSESSMENT

which is incorrect. Dropping the trailing slash makes the link link to the correct place:

http://127.0.0.1:4000/AUTOMATIC_BOOT_ASSESSMENT

Resolves: #32088
(cherry picked from commit d1a7e030c5daa4a09ee93b8af6b28ecaac5d34d0)
