### PR TITLE
core/varlink: make sure we setup non-serialized varlink sockets

### DIFF
--- a/src/core/manager-serialize.c
+++ b/src/core/manager-serialize.c
@@ -534,21 +534,12 @@ int manager_deserialize(Manager *m, FILE *f, FDSet *fds) {
                                 return -ENOMEM;
                 } else if ((val = startswith(l, "varlink-server-socket-address="))) {
                         if (!m->varlink_server && MANAGER_IS_SYSTEM(m)) {
-                                _cleanup_(varlink_server_unrefp) VarlinkServer *s = NULL;
-
-                                r = manager_setup_varlink_server(m, &s);
+                                r = manager_varlink_init(m);
                                 if (r < 0) {
                                         log_warning_errno(r, "Failed to setup varlink server, ignoring: %m");
                                         continue;
                                 }
 
-                                r = varlink_server_attach_event(s, m->event, SD_EVENT_PRIORITY_NORMAL);
-                                if (r < 0) {
-                                        log_warning_errno(r, "Failed to attach varlink connection to event loop, ignoring: %m");
-                                        continue;
-                                }
-
-                                m->varlink_server = TAKE_PTR(s);
                                 deserialize_varlink_sockets = true;
                         }
 


### PR DESCRIPTION
Before this PR, if m->varlink_server is not yet set up during deserialization, we call manager_setup_varlink_server rather than manager_varlink_init, the former of which doesn't setup varlink addresses, but only binds to methods. This results in that newly-added varlink addresses not getting created if deserialization takes place.

Therefore, let's switch to manager_varlink_init, and add some sanity checks to it in order to prevent listening on the same address twice.

Fixes #29373

Replaces #29421

(cherry picked from commit 6906c028e83b77b35eaaf87b27d0fe5c6e1984b7)