### PR TITLE
core/varlink: make sure we setup non-serialized varlink sockets

### DIFF
--- a/src/core/core-varlink.c
+++ b/src/core/core-varlink.c
@@ -504,13 +504,21 @@ static int manager_varlink_init_system(Manager *m) {
         if (!MANAGER_IS_TEST_RUN(m)) {
                 (void) mkdir_p_label("/run/systemd/userdb", 0755);
 
-                r = varlink_server_listen_address(s, "/run/systemd/userdb/io.systemd.DynamicUser", 0666);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to bind to varlink socket: %m");
+                FOREACH_STRING(address, "/run/systemd/userdb/io.systemd.DynamicUser", VARLINK_ADDR_PATH_MANAGED_OOM_SYSTEM) {
+                        if (MANAGER_IS_RELOADING(m)) {
+                                /* If manager is reloading, we skip listening on existing addresses, since
+                                 * the fd should be acquired later through deserialization. */
+                                if (access(address, F_OK) >= 0)
+                                        continue;
+                                if (errno != ENOENT)
+                                        return log_error_errno(errno,
+                                                               "Failed to check if varlink socket '%s' exists: %m", address);
+                        }
 
-                r = varlink_server_listen_address(s, VARLINK_ADDR_PATH_MANAGED_OOM_SYSTEM, 0666);
-                if (r < 0)
-                        return log_error_errno(r, "Failed to bind to varlink socket: %m");
+                        r = varlink_server_listen_address(s, address, 0666);
+                        if (r < 0)
+                                return log_error_errno(r, "Failed to bind to varlink socket '%s': %m", address);
+                }
         }
 
         r = varlink_server_attach_event(s, m->event, SD_EVENT_PRIORITY_NORMAL);

--- a/src/core/manager-serialize.c
+++ b/src/core/manager-serialize.c
@@ -534,21 +534,12 @@ int manager_deserialize(Manager *m, FILE *f, FDSet *fds) {
                                 return -ENOMEM;
                 } else if ((val = startswith(l, "varlink-server-socket-address="))) {
                         if (!m->varlink_server && MANAGER_IS_SYSTEM(m)) {
-                                _cleanup_(varlink_server_unrefp) VarlinkServer *s = NULL;
-
-                                r = manager_setup_varlink_server(m, &s);
+                                r = manager_varlink_init(m);
                                 if (r < 0) {
                                         log_warning_errno(r, "Failed to setup varlink server, ignoring: %m");
                                         continue;
                                 }
 
-                                r = varlink_server_attach_event(s, m->event, SD_EVENT_PRIORITY_NORMAL);
-                                if (r < 0) {
-                                        log_warning_errno(r, "Failed to attach varlink connection to event loop, ignoring: %m");
-                                        continue;
-                                }
-
-                                m->varlink_server = TAKE_PTR(s);
                                 deserialize_varlink_sockets = true;
                         }
 


### PR DESCRIPTION
Before this PR, if m->varlink_server is not yet set up during deserialization, we call manager_setup_varlink_server rather than manager_varlink_init, the former of which doesn't setup varlink addresses, but only binds to methods. This results in that newly-added varlink addresses not getting created if deserialization takes place.

Therefore, let's switch to manager_varlink_init, and add some sanity checks to it in order to prevent listening on the same address twice.

Fixes #29373

Replaces #29421

(cherry picked from commit 6906c028e83b77b35eaaf87b27d0fe5c6e1984b7) (cherry picked from commit cf84d7fc3e65523d2187c0ba68a61ac64802f4a2)