### PR TITLE
systemd-analyze: Add svg scaling options

### DIFF
--- a/man/systemd-analyze.xml
+++ b/man/systemd-analyze.xml
@@ -1499,6 +1499,24 @@ NR NAME                SHA256
         <xi:include href="version-info.xml" xpointer="v255"/></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><option>--scale-svg=<replaceable>FACTOR</replaceable></option></term>
+
+        <listitem><para>When used with the <command>plot</command> command, the x-axis of the plot
+        can be stretched by FACTOR (default: 1.0).</para>
+
+        <xi:include href="version-info.xml" xpointer="v255"/></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--detailed</option></term>
+
+        <listitem><para>When used with the <command>plot</command> command, activation timestamps
+        details can be seen in SVG plot.</para>
+
+        <xi:include href="version-info.xml" xpointer="v255"/></listitem>
+      </varlistentry>
+
       <xi:include href="standard-options.xml" xpointer="help" />
       <xi:include href="standard-options.xml" xpointer="version" />
       <xi:include href="standard-options.xml" xpointer="no-pager" />

--- a/shell-completion/bash/systemd-analyze
+++ b/shell-completion/bash/systemd-analyze
@@ -196,7 +196,7 @@ _systemd_analyze() {
 
     elif __contains_word "$verb" ${VERBS[PLOT]}; then
         if [[ $cur = -* ]]; then
-            comps='--help --version --system --user --global --no-pager --json=off --json=pretty --json=short --table --no-legend'
+            comps='--help --version --system --user --global --no-pager --json=off --json=pretty --json=short --table --no-legend --scale-svg --detailed'
         fi
     fi
 

--- a/src/analyze/analyze-plot.c
+++ b/src/analyze/analyze-plot.c
@@ -12,7 +12,7 @@
 #include "unit-def.h"
 #include "version.h"
 
-#define SCALE_X (0.1 / 1000.0) /* pixels per us */
+#define SCALE_X (0.1 * arg_svg_timescale / 1000.0) /* pixels per us */
 #define SCALE_Y (20.0)
 
 #define svg(...) printf(__VA_ARGS__)
@@ -29,6 +29,9 @@
                 svg(format, ## __VA_ARGS__);                            \
                 svg("</text>\n");                                       \
         } while (false)
+
+#define svg_timestamp(b, t, y) \
+        svg_text(b, t, y, "%u.%03us", (unsigned)((t) / USEC_PER_SEC), (unsigned)(((t) % USEC_PER_SEC) / USEC_PER_MSEC))
 
 
 typedef struct HostInfo {
@@ -358,6 +361,8 @@ static int produce_plot_as_svg(
         svg_bar("generators", boot->generators_start_time, boot->generators_finish_time, y);
         svg_bar("unitsload", boot->unitsload_start_time, boot->unitsload_finish_time, y);
         svg_text(true, boot->userspace_time, y, "systemd");
+        if (arg_detailed_svg)
+                svg_timestamp(false, boot->userspace_time, y);
         y++;
 
         for (; u->has_data; u++)

--- a/src/analyze/analyze.c
+++ b/src/analyze/analyze.c
@@ -99,6 +99,8 @@ RuntimeScope arg_runtime_scope = RUNTIME_SCOPE_SYSTEM;
 RecursiveErrors arg_recursive_errors = _RECURSIVE_ERRORS_INVALID;
 bool arg_man = true;
 bool arg_generators = false;
+double arg_svg_timescale = 1.0;
+bool arg_detailed_svg = false;
 char *arg_root = NULL;
 static char *arg_image = NULL;
 char *arg_security_policy = NULL;
@@ -271,6 +273,9 @@ static int help(int argc, char *argv[], void *userdata) {
                "     --profile=name|PATH     Include the specified profile in the\n"
                "                             security review of the unit(s)\n"
                "     --table                 Output plot's raw time data as a table\n"
+               "     --scale-svg=FACTOR      Stretch x-axis of plot by FACTOR (default: 1.0)\n"
+               "     --detailed              Add more details to SVG plot,\n"
+               "                             e.g. show activation timestamps\n"
                "  -h --help                  Show this help\n"
                "     --version               Show package version\n"
                "  -q --quiet                 Do not emit hints\n"
@@ -319,6 +324,8 @@ static int parse_argv(int argc, char *argv[]) {
                 ARG_TABLE,
                 ARG_NO_LEGEND,
                 ARG_TLDR,
+                ARG_SCALE_FACTOR_SVG,
+                ARG_DETAILED_SVG,
         };
 
         static const struct option options[] = {
@@ -544,6 +551,14 @@ static int parse_argv(int argc, char *argv[]) {
 
                 case ARG_TLDR:
                         arg_cat_flags = CAT_TLDR;
+                        break;
+
+                case ARG_SCALE_FACTOR_SVG:
+                        arg_svg_timescale = strtod(optarg, NULL);
+                        break;
+
+                case ARG_DETAILED_SVG:
+                        arg_detailed_svg = true;
                         break;
 
                 case '?':

--- a/src/analyze/analyze.h
+++ b/src/analyze/analyze.h
@@ -28,6 +28,8 @@ extern RuntimeScope arg_runtime_scope;
 extern RecursiveErrors arg_recursive_errors;
 extern bool arg_man;
 extern bool arg_generators;
+extern double arg_svg_timescale;
+extern bool arg_detailed_svg;
 extern char *arg_root;
 extern char *arg_security_policy;
 extern bool arg_offline;


### PR DESCRIPTION
+ Scale the x-axis of the resulting plot by a factor (default 1.0)
+ Add activation timestamps to each bar

Backport https://github.com/systemd/systemd/pull/33858 to v255