### PR TITLE
mkosi: install libgcrypt20 manually in debian

### DIFF
--- a/mkosi.images/base/mkosi.conf.d/10-debian.conf
+++ b/mkosi.images/base/mkosi.conf.d/10-debian.conf
@@ -6,6 +6,8 @@ Distribution=debian
 [Content]
 Packages=
         libbpf1
+        libgcrypt20
+        libcryptsetup12
 
 BuildPackages=
         bpftool


### PR DESCRIPTION
Fixes kernel panic when booting in qemu