### PR TITLE
[v253] Drop log level of header limits log message

### DIFF
--- a/src/journal/journald-server.c
+++ b/src/journal/journald-server.c
@@ -930,10 +930,9 @@ static void server_write_to_journal(Server *s, uid_t uid, struct iovec *iovec, s
                 if (!f)
                         return;
 
-                if (journal_file_rotate_suggested(f->file, s->max_file_usec, LOG_INFO)) {
-                        log_ratelimit_info(JOURNAL_LOG_RATELIMIT,
-                                           "%s: Journal header limits reached or header out-of-date, rotating.",
-                                           f->file->path);
+                if (journal_file_rotate_suggested(f->file, s->max_file_usec, LOG_DEBUG)) {
+                        log_debug("%s: Journal header limits reached or header out-of-date, rotating.",
+                                  f->file->path);
                         rotate = true;
                 }
         }


### PR DESCRIPTION
Especially when using in-memory logging, these are too noisy so let's drop them back to debug level.

(cherry picked from commit afc47ee2af456d12670df862457dcc7f6b864d79)