### PR TITLE
[v255] test: fix TEST-84-STORAGETM with nvme-cli < 2.7

### DIFF
--- a/test/units/testsuite-84.sh
+++ b/test/units/testsuite-84.sh
@@ -11,6 +11,11 @@ if systemd-analyze compare-versions "$(nvme --version | grep libnvme | awk '{pri
     fi
 fi
 
+VERBOSE=""
+if systemd-analyze compare-versions "$(nvme --version | grep '^nvme' | awk '{print $3}')" ge 2.7; then
+    VERBOSE="-vv"
+fi
+
 modprobe -v nvmet-tcp
 modprobe -v nvme-tcp
 
@@ -22,7 +27,7 @@ NVME_UUID="$(cat /proc/sys/kernel/random/uuid)"
 systemd-run -u teststoragetm.service -p Type=notify -p "Environment=SYSTEMD_NVME_UUID=${NVME_UUID:?}" /usr/lib/systemd/systemd-storagetm /var/tmp/storagetm.test --nqn=quux
 NVME_DEVICE="/dev/disk/by-id/nvme-uuid.${NVME_UUID:?}"
 
-nvme connect-all -vv -t tcp -a 127.0.0.1 -s 16858 --hostnqn="$(nvme gen-hostnqn)"
+nvme connect-all "${VERBOSE}" -t tcp -a 127.0.0.1 -s 16858 --hostnqn="$(nvme gen-hostnqn)"
 udevadm wait --settle "$NVME_DEVICE"
 
 dd if="$NVME_DEVICE" bs=1024 | cmp /var/tmp/storagetm.test -


### PR DESCRIPTION
The -vv parameter was added in version 2.7, check before using it

Follow-up for ebc0514a6507d51e536b269e30a036a7992beeb7

(cherry picked from commit 60491ceb12aac9f2b9423490158bd9291d735b36)
(cherry picked from commit f75ca4648efd92e6a7a5a244a5de09187a30e43c)
(cherry picked from commit 4227d16e5623ed085afe5a4773fa81845ffa0179)